### PR TITLE
Update astroconda specviz package to latest version

### DIFF
--- a/specviz/meta.yaml
+++ b/specviz/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'specviz' %}
-{% set version = '0.1.2rc3' %}
-{% set tag = 'v0.1.2rc3' %}
+{% set version = '0.2.0rc3' %}
+{% set tag = 'v0.2.0rc3' %}
 {% set number = '0' %}
 
 package:
@@ -17,7 +17,7 @@ requirements:
     - cython
     - jinja2
     - pyyaml
-    - pyqtgraph >=0.9.10
+    - pyqtgraph >=0.9.11
     - pyqt
     - scipy
     - yaml
@@ -30,7 +30,7 @@ requirements:
     - cython
     - jinja2
     - pyyaml
-    - pyqtgraph >=0.9.10
+    - pyqtgraph >=0.9.11
     - pyqt
     - scipy
     - yaml


### PR DESCRIPTION
@jhunkeler The current specviz really requires pyqtgraph version 0.9.11, which isn't in any distribution yet (pip/conda/etc). I had packaged it in my channel, but you can't set conda channels for dependency installs for anaconda.

Would it be possible to host the 0.9.11 version temporarily on astroconda?