### PR TITLE
Update pyqtgraph to latest "develop" build; with inline retag

### DIFF
--- a/pyqtgraph/build.sh
+++ b/pyqtgraph/build.sh
@@ -1,2 +1,2 @@
-
+git tag -a 0.9.11.dev -m 'Fake update to 0.9.11'
 python setup.py install || exit 1

--- a/pyqtgraph/meta.yaml
+++ b/pyqtgraph/meta.yaml
@@ -1,26 +1,34 @@
 about:
     home: http://www.pyqtgraph.org/
     license: MIT
-    summary: pyqtgraph
+    summary: A pure-Python graphics library for PyQt/PySide (git master build)
+
 build:
     number: '0'
+
 package:
     name: pyqtgraph
-    version: 0.9.10
+    version: 0.9.11
+
 requirements:
     build:
     - setuptools
+    - numpy x.x
     - python x.x
     run:
     - pyqt
     - pyopengl
     - numpy x.x
     - python x.x
+
 source:
-    fn: pyqtgraph-0.9.10.tar.gz
-    md5: bd84bf7537c43cf38db81cc1ad4f743a
-    url:
-    - https://pypi.python.org/packages/source/p/pyqtgraph/pyqtgraph-0.9.10.tar.gz
+    git_rev: 670d63cd
+    git_url: https://github.com/pyqtgraph/pyqtgraph.git
+
 test:
-    imports:
+  requires:
+    - pyqt
+    - numpy
+  imports:
     - pyqtgraph
+


### PR DESCRIPTION
The recipe uses `git_rev` to grab a specific commit hash, rather than building from HEAD. This prevents constant rebuilds.

Requirement of: #13 