### PR TITLE
Pywcs removal

### DIFF
--- a/reftools/meta.yaml
+++ b/reftools/meta.yaml
@@ -3,7 +3,7 @@ about:
     license: BSD
     summary: reftools
 build:
-    number: '0'
+    number: '1'
     preserve_egg_dir: 'yes'
 package:
     name: reftools
@@ -14,7 +14,6 @@ requirements:
     - stsci.distutils
     - stsci.imagestats
     - stsci.tools
-    - pywcs
     - pysynphot
     - stwcs
     - calcos
@@ -25,7 +24,6 @@ requirements:
     run:
     - stsci.imagestats
     - stsci.tools
-    - pywcs
     - pysynphot
     - stwcs
     - calcos

--- a/stsci-hst/meta.yaml
+++ b/stsci-hst/meta.yaml
@@ -6,7 +6,7 @@ build:
     number: '0'
 package:
     name: stsci-hst
-    version: 1.0.1
+    version: 1.0.2
 requirements:
     build:
     - purge_path >=0.0.1
@@ -23,7 +23,6 @@ requirements:
     - nictools ==1.1.3
     - pyregion ==1.1.2
     - pysynphot ==0.9.8.2
-    - pywcs ==1.12.1
     - reftools ==1.7.1
     - stistools ==1.1
     - stsci.convolve ==2.1.3
@@ -58,7 +57,6 @@ requirements:
     - nictools ==1.1.3
     - pyregion ==1.1.2
     - pysynphot ==0.9.8.2
-    - pywcs ==1.12.1
     - reftools ==1.7.1
     - stistools ==1.1
     - stsci.convolve ==2.1.3


### PR DESCRIPTION
Remove deprecated pywcs package from the build

EDIT: The `reftools` package released in `stsci-hst` never required `pywcs` to begin with. Therefore it is safe to remove. No packages require `pywcs` (everything has switched over to `astropy.wcs`).