### PR TITLE
Reupgrade pyobjc to 3.1.1

### DIFF
--- a/pyobjc-core/meta.yaml
+++ b/pyobjc-core/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'pyobjc-core' %}
-{% set version = '3.0.4' %}
+{% set version = '3.1.1' %}
 {% set number = '0' %}
 
 about:

--- a/pyobjc-framework-cocoa/meta.yaml
+++ b/pyobjc-framework-cocoa/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'pyobjc-framework-cocoa' %}
-{% set version = '3.0.4' %}
+{% set version = '3.1.1' %}
 {% set number = '0' %}
 
 about:

--- a/pyobjc-framework-quartz/meta.yaml
+++ b/pyobjc-framework-quartz/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'pyobjc-framework-quartz' %}
-{% set version = '3.0.4' %}
+{% set version = '3.1.1' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Previous downgrade was not required. The new metapackage requirement settings make this a safe choice once again.