### PR TITLE
Update HSTCAL to 1.0.1

### DIFF
--- a/hstcal/meta.yaml
+++ b/hstcal/meta.yaml
@@ -6,12 +6,12 @@ build:
     number: '0'
 package:
     name: hstcal
-    version: 1.0.0
+    version: 1.0.1
 requirements:
     build:
     - gcc >=4.6 [osx]
     run:
     - libgcc >=4.6 [osx]
 source:
-    git_tag: 1.0.0
+    git_tag: 1.0.1
     git_url: https://github.com/spacetelescope/hstcal


### PR DESCRIPTION
Bumped HSTCAL to 1.0.1 to support new ACS subarrays, as requested by @stsci-hack .