### PR TITLE
Update photutils to v0.2.2

### DIFF
--- a/photutils/build.sh
+++ b/photutils/build.sh
@@ -1,4 +1,1 @@
-
-echo This d2to1 hack is deadly.
-pip install --no-deps --upgrade --force d2to1 || exit 1
 python setup.py install || exit 1

--- a/photutils/meta.yaml
+++ b/photutils/meta.yaml
@@ -6,7 +6,7 @@ build:
     number: '1'
 package:
     name: photutils
-    version: 0.2.1
+    version: 0.2.2
 requirements:
     build:
     - d2to1
@@ -28,7 +28,7 @@ requirements:
     - setuptools
     - python x.x
 source:
-    git_tag: v0.2.1
+    git_tag: v0.2.2
     git_url: https://github.com/astropy/photutils
 test:
     imports:

--- a/photutils/meta.yaml
+++ b/photutils/meta.yaml
@@ -9,7 +9,6 @@ package:
     version: 0.2.2
 requirements:
     build:
-    - d2to1
     - astropy >=1.1
     - cython
     - matplotlib

--- a/photutils/meta.yaml
+++ b/photutils/meta.yaml
@@ -16,7 +16,6 @@ requirements:
     - matplotlib
     - numpy x.x
     - scikit-image
-    - scikit-learn
     - scipy
     - setuptools
     - python x.x
@@ -26,7 +25,6 @@ requirements:
     - matplotlib
     - numpy x.x
     - scikit-image
-    - scikit-learn
     - scipy
     - setuptools
     - python x.x

--- a/photutils/meta.yaml
+++ b/photutils/meta.yaml
@@ -10,7 +10,6 @@ package:
 requirements:
     build:
     - d2to1
-    - nose
     - astropy >=1.1
     - cython
     - matplotlib


### PR DESCRIPTION
Also removes so unused dependencies.

I left `d2to1` in `meta.yaml` in case you need it for your builds in some way, but strictly speaking `photutils` does not use `d2to1`.