### PR TITLE
Update specviz to RC5 so it will build in Python 3

### DIFF
--- a/specviz/meta.yaml
+++ b/specviz/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'specviz' %}
-{% set version = '0.2.1rc4' %}
-{% set tag = 'v0.2.1rc4' %}
+{% set version = '0.2.1rc5' %}
+{% set tag = 'v0.2.1rc5' %}
 {% set number = '0' %}
 
 package:


### PR DESCRIPTION
Update `specviz` to RC5 so it will build in Python 3. Also see spacetelescope/specviz#212 and spacetelescope/specviz#213. c/c @nmearl 