### PR TITLE
Updated acstools recipe to support 2.0.4

### DIFF
--- a/acstools/bld.bat
+++ b/acstools/bld.bat
@@ -1,7 +1,2 @@
-
-echo This d2to1 hack is deadly.
-pip install --no-deps --upgrade --force d2to1
-if errorlevel 1 exit 1
-
 python setup.py install || exit 1
 if errorlevel 1 exit 1

--- a/acstools/build.sh
+++ b/acstools/build.sh
@@ -1,3 +1,1 @@
-echo This d2to1 hack is deadly.
-pip install --no-deps --upgrade --force d2to1 || exit 1
 python setup.py install || exit 1

--- a/acstools/meta.yaml
+++ b/acstools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'acstools' %}
-{% set version = '2.0.2' %}
+{% set version = '2.0.3' %}
 {% set number = '0' %}
 
 about:
@@ -13,13 +13,11 @@ package:
     version: {{ version }}
 requirements:
     build:
-    - d2to1
-    - stsci.distutils
     - python x.x
     - astropy >=1.1
     - numpy x.x
     - scipy
-    - scikit-image
+    - scikit-image >= 0.11
     - matplotlib
     - stsci.imagestats
     - stsci.tools
@@ -28,7 +26,7 @@ requirements:
     - astropy >=1.1
     - numpy x.x
     - scipy
-    - scikit-image
+    - scikit-image >= 0.11
     - matplotlib
     - stsci.imagestats
     - stsci.tools

--- a/acstools/meta.yaml
+++ b/acstools/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     run:
     - astropy >=1.1
     - numpy x.x
-    - setuptools
     - python x.x
 source:
     git_tag: {{ version }}

--- a/acstools/meta.yaml
+++ b/acstools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'acstools' %}
-{% set version = '2.0.3' %}
+{% set version = '2.0.4' %}
 {% set number = '0' %}
 
 about:
@@ -13,23 +13,13 @@ package:
     version: {{ version }}
 requirements:
     build:
-    - python x.x
     - astropy >=1.1
     - numpy x.x
-    - scipy
-    - scikit-image >= 0.11
-    - matplotlib
-    - stsci.imagestats
-    - stsci.tools
     - setuptools
+    - python x.x
     run:
     - astropy >=1.1
     - numpy x.x
-    - scipy
-    - scikit-image >= 0.11
-    - matplotlib
-    - stsci.imagestats
-    - stsci.tools
     - setuptools
     - python x.x
 source:


### PR DESCRIPTION
Updated acstools recipe to support 2.0.4:

* Bumped version to 2.0.4 (also see spacetelescope/acstools#8 and spacetelescope/acstools#10)
* Removed "deadly" `d2to1` hack in build scripts
* Removed unneeded dependencies from meta

@jhunkeler , if this breaks the build, please let me know and I'll update the PR. Thanks!