### PR TITLE
Update reftools to 1.7.3

### DIFF
--- a/reftools/meta.yaml
+++ b/reftools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'reftools' %}
-{% set version = '1.7.2' %}
+{% set version = '1.7.3' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Update `reftools` to 1.7.3 to fix build error due to accidentally importing optional import (`stsci.tools`).