### PR TITLE
Remove or silence 2to3 execution

### DIFF
--- a/nictools/bld.bat
+++ b/nictools/bld.bat
@@ -1,4 +1,3 @@
 
 python setup.py install
-2to3 -w .
 if errorlevel 1 exit 1

--- a/pyraf/build.sh
+++ b/pyraf/build.sh
@@ -5,7 +5,11 @@ fi
 
 if [[ $PY3K > 0 ]]; then
 set +e
-    2to3 -w .
+    echo Running 2to3...
+    2to3 -w . &>/dev/null
+    if [[ $? != 0 ]]; then
+        echo "ERROR: 2to3 technically failed!"
+    fi
 fi
 
 python setup.py install || exit 1

--- a/stsci.skypac/bld.bat
+++ b/stsci.skypac/bld.bat
@@ -1,4 +1,3 @@
 
 python setup.py install
-2to3 -w .
 if errorlevel 1 exit 1

--- a/stsci.skypac/build.sh
+++ b/stsci.skypac/build.sh
@@ -23,6 +23,5 @@ set_py3k
 pip install --no-deps --upgrade --force d2to1
 if [ $PY3K -ne 0 ] ; then
 sed -i -e "s|stsci.distutils.hooks.tag_svn_revision|#removed|" setup.cfg
-2to3 -w .
 fi
 python setup.py install || exit 1

--- a/wfpc2tools/build.sh
+++ b/wfpc2tools/build.sh
@@ -5,15 +5,15 @@ python --version 2>&1| awk '{sub(/-.*/,"",$2);print $2}'
 export -f get_py_version
 
 function set_py3k() {
-version=`get_py_version`
-major=`echo $version | cut -d '.' -f 1`
-minor=`echo $version | cut -d '.' -f 2`
-hotfix=`echo $version | cut -d '.' -f 3`
-if (( major > 2 )); then
-export PY3K=1
-else
-export PY3K=0
-fi
+    version=`get_py_version`
+    major=`echo $version | cut -d '.' -f 1`
+    minor=`echo $version | cut -d '.' -f 2`
+    hotfix=`echo $version | cut -d '.' -f 3`
+    if (( major > 2 )); then
+        export PY3K=1
+    else
+        export PY3K=0
+    fi
 }
 export -f set_py3k
 
@@ -24,7 +24,6 @@ pip install --no-deps --upgrade --force d2to1 || exit 1
 echo "This doesn't work. Why conda why? --python 2.7 is useless here"
 if [ $PY3K -ne 0 ] ; then
 sed -i -e "s|stsci.distutils.hooks.tag_svn_revision|#removed|" setup.cfg
-2to3 -w .
 fi
 
 python setup.py install || exit 1


### PR DESCRIPTION
Does what it says on the box. Simply either remove 2to3 usage or silence its output completely, because the build logs are as indecipherable as they are gigantic. 