### PR TITLE
Update verhawk v0.0.2

### DIFF
--- a/verhawk/meta.yaml
+++ b/verhawk/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'verhawk' %}
-{% set version = '0.0.1' %}
+{% set version = '0.0.2' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Fixes python 2.7 build failure.