### PR TITLE
calcos: Use "-r" to print version instead of non-existent "--help"

### DIFF
--- a/calcos/meta.yaml
+++ b/calcos/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'calcos' %}
 {% set version = '3.1.8' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}
@@ -31,6 +31,6 @@ source:
     git_url: https://github.com/spacetelescope/{{ name }}.git
 test:
     commands:
-    - calcos --help
+    - calcos -r
     imports:
     - calcos


### PR DESCRIPTION
The build test completes successfully, but `--help` is not a valid option. Let's just print the version with `-r` instead.