### PR TITLE
Upgrade pysynphot to 0.9.8.5

### DIFF
--- a/pysynphot/meta.yaml
+++ b/pysynphot/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'pysynphot' %}
-{% set version = '0.9.8.4' %}
+{% set version = '0.9.8.5' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Upgrade `pysynphot` to 0.9.8.5 with bug fixes to `redshift()` method for `SourceSpectrum` and `Box` spectral element.