### PR TITLE
Remove webbpsf and dependencies from base environment

### DIFF
--- a/stsci/meta.yaml
+++ b/stsci/meta.yaml
@@ -6,7 +6,7 @@ build:
     number: '0'
 package:
     name: stsci
-    version: 1.0.1
+    version: 1.0.2
 requirements:
     build:
     - stsci-hst
@@ -19,12 +19,9 @@ requirements:
     - htc_utils >=0.1
     - imexam >=0.5.2
     - photutils >=0.2.1
-    - poppy >=0.4.0
     - purge_path >=1.0.0
     - pyds9 >=1.8.1
     - pyfftw >=0.9.2
-    - webbpsf >=0.4.0
-    - webbpsf-data >=0.4.0
     - numpy x.x
     - python x.x
     run:
@@ -38,11 +35,8 @@ requirements:
     - htc_utils >=0.1
     - imexam >=0.5.2
     - photutils >=0.2.1
-    - poppy >=0.4.0
     - purge_path >=1.0.0
     - pyds9 >=1.8.1
     - pyfftw >=0.9.2
-    - webbpsf >=0.4.0
-    - webbpsf-data >=0.4.0
     - numpy x.x
     - python x.x


### PR DESCRIPTION
Removes `webbpsf`, `webbpsf-data`, and `poppy` from the `stsci` metapackage. They will continue to be built and distributed, but not attached directly to the default user environment.