### PR TITLE
sextractor no-quote options

### DIFF
--- a/sextractor/build.sh
+++ b/sextractor/build.sh
@@ -22,7 +22,7 @@ esac
 ./configure --prefix=$PREFIX \
     --with-fftw-libdir=$PREFIX/lib \
     --with-fftw-incdir=$PREFIX/include \
-    "${OPTIONS}"
+    ${OPTIONS}
 
 make -j ${CPU_COUNT}
 make install


### PR DESCRIPTION
Final iteration. Builds were succeeding but not linking properly due to busted `"$OPTIONS"`