### PR TITLE
Update glue to v0.9

### DIFF
--- a/glue-vispy-viewers/LICENSE
+++ b/glue-vispy-viewers/LICENSE
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/glue-vispy-viewers/meta.yaml
+++ b/glue-vispy-viewers/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4" %}
+{% set version = "0.5" %}
 
 package:
   name: glue-vispy-viewers
@@ -7,10 +7,10 @@ package:
 source:
   fn: glue-vispy-viewers-{{version}}.tar.gz
   url: https://pypi.io/packages/source/g/glue-vispy-viewers/glue-vispy-viewers-{{version}}.tar.gz
-  md5: ded543ba93070a71f322da650b792b16
+  md5: 28ca4b50dc179609d8304b4e5e8e6042
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -23,16 +23,19 @@ requirements:
     - python
     - numpy
     - pyopengl
-    - glueviz
+    - glueviz >=0.9
     - scikit-image
     - matplotlib
+    - qtpy
+
+    # At the moment, the 3D viewers don't yet work properly with Qt5, so we pin to 4.x
+    - pyqt 4.*
 
 test:
-  requires:
-    - mock
-    - pytest
   imports:
     - glue_vispy_viewers
+    - glue_vispy_viewers.scatter
+    - glue_vispy_viewers.volume
 
 about:
   home: https://github.com/glue-viz/glue-vispy-viewers

--- a/glueviz/LICENSE
+++ b/glueviz/LICENSE
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/glueviz/meta.yaml
+++ b/glueviz/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.2" %}
+{% set version = "0.9.0" %}
 
 package:
   name: glueviz
@@ -7,10 +7,10 @@ package:
 source:
   fn: glueviz-{{version}}.tar.gz
   url: https://pypi.io/packages/source/g/glueviz/glueviz-{{version}}.tar.gz
-  md5: 92dd7de2621a6ab6861cc9b689e86c3e
+  md5: 34b4923e4e2441a95b1830ede26ddca2
 
 build:
-  number: 0
+  number: 2
   script: python setup.py install --single-version-externally-managed --record record.txt
   osx_is_app: True
 
@@ -18,29 +18,46 @@ requirements:
 
   build:
     - python
+    - setuptools
 
   run:
-    - python
-    - numpy
-    - scipy
-    - matplotlib
-    - astropy
-    - ipython
-    - ipykernel
-    - h5py
-    - pandas
-    - pyqt
-    - qtconsole
-    - xlrd
-    - scikit-image
+
+    # The following is needed to make sure that the package works as a GUI
+    # application (glue needs to be run with python.app, not python)
     - python.app  # [osx]
 
+    # Required dependencies
+    - python
+    - numpy
+    - pandas
+    - astropy >=1
+    - matplotlib
+    - qtpy >=1.1.1
+    - setuptools
+
+    # The conda-forge version of Qt 4.11.4 is currently broken because
+    # it doesn't include session-related functionality, so we disallow
+    # this version for now.
+    - pyqt !=4.11.4  # [linux]
+    - pyqt  # [not linux]
+
+    # Optional dependencies (defined in ``extras_require``)
+    - dill
+    - h5py
+    - scipy
+    - scikit-image
+    - ipython >=1
+    - ipykernel
+    - qtconsole
+    - plotly
+    - xlrd
+    - glue-vispy-viewers >=0.5
+
 test:
-  requires:
-    - mock
-    - pytest
   imports:
     - glue
+    - glue.core
+    - glue.app.qt
   commands:
     - glue --version
     - glue-deps list
@@ -54,6 +71,7 @@ app:
 about:
   home: http://glueviz.org
   license: BSD 3-Clause
+  license_file: LICENSE
   summary: Multi-dimensional linked data exploration
 
 extra:

--- a/qtpy/LICENSE
+++ b/qtpy/LICENSE
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/qtpy/meta.yaml
+++ b/qtpy/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "1.1.1" %}
+
+package:
+  name: qtpy
+  version: {{version}}
+
+source:
+  fn: qtpy-{{version}}.tar.gz
+  url: https://pypi.io/packages/source/q/qtpy/QtPy-{{version}}.tar.gz
+  md5: 181a1cc9c010e0c1f4daa3f0f69e3782
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  requires:
+    - pyqt
+  imports:
+    - qtpy
+
+about:
+  home: https://github.com/spyder-ide/qtpy
+  license: MIT
+  summary: A uniform layer to support PyQt5, PyQt4 and PySide with a single codebase
+


### PR DESCRIPTION
Here are updated recipes for glue v0.9 based on the versions in conda-forge. I also copied over the QtPy recipe since the version in the defaults channel is too old. Finally I also included the LICENSE files from the conda-forge recipes so everything is 'proper'.

**Note:** I think the glueviz and glue-vispy-viewers recipes will need to be built together since they inter-depend on each other.

cc @justincely @kassin