### PR TITLE
pyds9 1.8.1 -> 1.9.x master

### DIFF
--- a/pyds9/build.sh
+++ b/pyds9/build.sh
@@ -1,2 +1,1 @@
-
-python setup.py install || exit 1
+python setup.py install

--- a/pyds9/meta.yaml
+++ b/pyds9/meta.yaml
@@ -1,28 +1,32 @@
 about:
     home: https://github.com/ericmandel/pyds9
     license: GPL
-    summary: Python connection to SAOimage DS9 via XPA
+    summary: |
+        (Supervised master build)
+        Python connection to SAOimage DS9 via XPA
 build:
-    number: '1'
+    number: '0'
+    string: {{ GIT_BUILD_STR }}
 package:
     name: pyds9
-    version: 1.8.1
+    version: 1.9.0.dev
 requirements:
     build:
-    - xpa
+    - astropy
+    - cython
     - ds9
     - six
     - setuptools
     - numpy x.x
     - python x.x
     run:
-    - xpa
+    - astropy
     - ds9
     - six
     - numpy x.x
     - python x.x
 source:
-    git_tag: v1.8.1
+    git_rev: 3761d7ac151f8c8729d0fb6cdba017cadf278283
     git_url: https://github.com/ericmandel/pyds9
 test:
     imports:


### PR DESCRIPTION
The installation bug(s) in 1.8.x leave us no choice here. In local testing I haven't noticed any oddities with this 1.9.x development build, so I'm pushing it into the astroconda-channel.

I verified `pyds9-1.9.0.dev-61_g3761d7a` will be overwritten properly if/when the `pyds9-1.9.0` package is released, so we shouldn't have to worry about that when the time comes. 

Until then, I may update the `git_rev` periodically.

I removed the hard dependency on the `xpa` conda package. It doesn't conflict, however it isn't used either. In other words, there's no point in including it. If you want an independent XPA, then do `conda install xpa`, otherwise just use whatever is provided by `pyds9`.

Forcing the end-user to use libxpa provided by pyds9's source is unacceptable. Hopefully some day the maintainers will fix this (i.e. `python setup.py --use-system-libxpa` does NOT work).

Related:
https://github.com/astroconda/astroconda/issues/15

