### PR TITLE
WebbPSF and POPPY v0.5.1

### DIFF
--- a/jwxml/bld.bat
+++ b/jwxml/bld.bat
@@ -1,0 +1,3 @@
+
+python setup.py install
+if errorlevel 1 exit 1

--- a/jwxml/build.sh
+++ b/jwxml/build.sh
@@ -1,0 +1,2 @@
+
+python setup.py install || exit 1

--- a/jwxml/meta.yaml
+++ b/jwxml/meta.yaml
@@ -4,7 +4,6 @@ about:
     summary: jwxml
 build:
     number: '0'
-    preserve_egg_dir: 'True'
 package:
     name: jwxml
     version: 0.1.0

--- a/jwxml/meta.yaml
+++ b/jwxml/meta.yaml
@@ -1,0 +1,25 @@
+about:
+    home: https://github.com/mperrin/jwxml
+    license: BSD
+    summary: jwxml
+build:
+    number: '0'
+    preserve_egg_dir: 'True'
+package:
+    name: jwxml
+    version: 0.1.0
+requirements:
+    build:
+    - numpy x.x
+    - matplotlib
+    - python x.x
+    run:
+    - numpy x.x
+    - matplotlib
+    - python x.x
+source:
+    git_tag: v0.1.0
+    git_url: https://github.com/mperrin/jwxml
+test:
+    commands:
+    - python -c 'from jwxml.siaf import SIAF; SIAF(instr="NIRCam")'

--- a/poppy/meta.yaml
+++ b/poppy/meta.yaml
@@ -6,7 +6,7 @@ build:
     number: '0'
 package:
     name: poppy
-    version: 0.5.0
+    version: 0.5.1
 requirements:
     build:
     - nose
@@ -31,5 +31,5 @@ requirements:
     - setuptools
     - python x.x
 source:
-    git_tag: v0.5.0
+    git_tag: v0.5.1
     git_url: https://github.com/mperrin/poppy

--- a/poppy/meta.yaml
+++ b/poppy/meta.yaml
@@ -9,24 +9,20 @@ package:
     version: 0.5.1
 requirements:
     build:
-    - nose
     - astropy >=1.1
     - numpy x.x
     - scipy
     - matplotlib
     - six [py27]
-    - mock [py27]
     - enum34 [py27]
     - setuptools
     - python x.x
     run:
-    - nose
     - astropy >=1.1
     - numpy x.x
     - scipy
     - matplotlib
     - six [py27]
-    - mock [py27]
     - enum34 [py27]
     - setuptools
     - python x.x

--- a/webbpsf/meta.yaml
+++ b/webbpsf/meta.yaml
@@ -10,7 +10,6 @@ package:
     version: 0.5.1
 requirements:
     build:
-    - nose
     - astropy >=1.1
     - numpy x.x
     - scipy
@@ -22,7 +21,6 @@ requirements:
     - python x.x
     - ipywidgets
     run:
-    - nose
     - astropy >=1.1
     - numpy x.x
     - scipy

--- a/webbpsf/meta.yaml
+++ b/webbpsf/meta.yaml
@@ -7,7 +7,7 @@ build:
     preserve_egg_dir: 'True'
 package:
     name: webbpsf
-    version: 0.5.0
+    version: 0.5.1
 requirements:
     build:
     - nose
@@ -20,6 +20,7 @@ requirements:
     - webbpsf-data ==0.5.0
     - setuptools
     - python x.x
+    - ipywidgets
     run:
     - nose
     - astropy >=1.1
@@ -31,8 +32,9 @@ requirements:
     - webbpsf-data ==0.5.0
     - setuptools
     - python x.x
+    - ipywidgets
 source:
-    git_tag: v0.5.0
+    git_tag: v0.5.1
     git_url: https://github.com/mperrin/webbpsf
 test:
     commands:

--- a/webbpsf/meta.yaml
+++ b/webbpsf/meta.yaml
@@ -14,23 +14,25 @@ requirements:
     - numpy x.x
     - scipy
     - matplotlib
-    - poppy >=0.5.0
+    - poppy >=0.5.1
     - six [py27]
     - webbpsf-data ==0.5.0
     - setuptools
     - python x.x
     - ipywidgets
+    - jwxml
     run:
     - astropy >=1.1
     - numpy x.x
     - scipy
     - matplotlib
-    - poppy >=0.5.0
+    - poppy >=0.5.1
     - six [py27]
     - webbpsf-data ==0.5.0
     - setuptools
     - python x.x
     - ipywidgets
+    - jwxml
 source:
     git_tag: v0.5.1
     git_url: https://github.com/mperrin/webbpsf


### PR DESCRIPTION
~~**Note:** v0.1.0 is not yet tagged for mperrin/jwxml.~~

This makes WebbPSF and POPPY 0.5.1 available for AstroConda users. They're available in PyPI already.
