### PR TITLE
Fix spaces between match specifiers

### DIFF
--- a/stsci-data-analysis/meta.yaml
+++ b/stsci-data-analysis/meta.yaml
@@ -13,9 +13,9 @@ requirements:
     - astroimtools >=0.1
     - stginga >=0.1
     - specviz
-    - photutils >= 0.2.2
-    - glueviz >= 0.9.0
-    - imexam >= 0.6.2
+    - photutils >=0.2.2
+    - glueviz >=0.9.0
+    - imexam >=0.6.2
     - asdf >=1.0.2
     - numpy x.x
     - python x.x
@@ -24,9 +24,9 @@ requirements:
     - astroimtools >=0.1
     - stginga >=0.1
     - specviz
-    - photutils >= 0.2.2
-    - glueviz >= 0.9.0
-    - imexam >= 0.6.2
+    - photutils >=0.2.2
+    - glueviz >=0.9.0
+    - imexam >=0.6.2
     - asdf >=1.0.2
     - numpy x.x
     - python x.x


### PR DESCRIPTION
@justincely I didn't notice these syntax errors on Friday. Merging the fix now.