### PR TITLE
Update glueviz to 0.9.1 and glue-vispy-viewers to 0.6

### DIFF
--- a/glue-vispy-viewers/meta.yaml
+++ b/glue-vispy-viewers/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.5" %}
+{% set version = "0.6" %}
 
 package:
   name: glue-vispy-viewers
@@ -7,10 +7,10 @@ package:
 source:
   fn: glue-vispy-viewers-{{version}}.tar.gz
   url: https://pypi.io/packages/source/g/glue-vispy-viewers/glue-vispy-viewers-{{version}}.tar.gz
-  md5: 28ca4b50dc179609d8304b4e5e8e6042
+  md5: 07b0ec9fec510352edc617e95ee86469
 
 build:
-  number: 1
+  number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -27,9 +27,7 @@ requirements:
     - scikit-image
     - matplotlib
     - qtpy
-
-    # At the moment, the 3D viewers don't yet work properly with Qt5, so we pin to 4.x
-    - pyqt 4.*
+    - pyqt
 
 test:
   imports:

--- a/glueviz/meta.yaml
+++ b/glueviz/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.9.0" %}
+{% set version = "0.9.1" %}
 
 package:
   name: glueviz
@@ -7,10 +7,10 @@ package:
 source:
   fn: glueviz-{{version}}.tar.gz
   url: https://pypi.io/packages/source/g/glueviz/glueviz-{{version}}.tar.gz
-  md5: 34b4923e4e2441a95b1830ede26ddca2
+  md5: 365887017580e243fb008d8109f2bc16
 
 build:
-  number: 2
+  number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
   osx_is_app: True
 
@@ -28,18 +28,13 @@ requirements:
 
     # Required dependencies
     - python
-    - numpy
-    - pandas
+    - numpy >=1.9
+    - pandas >=0.14
     - astropy >=1
-    - matplotlib
+    - matplotlib >=1.4
     - qtpy >=1.1.1
-    - setuptools
-
-    # The conda-forge version of Qt 4.11.4 is currently broken because
-    # it doesn't include session-related functionality, so we disallow
-    # this version for now.
-    - pyqt !=4.11.4  # [linux]
-    - pyqt  # [not linux]
+    - setuptools >=1.0
+    - pyqt
 
     # Optional dependencies (defined in ``extras_require``)
     - dill


### PR DESCRIPTION
@justincely - this unpins the 3D viewers from PyQt4. Once this is merged, it would be great if you/others could test glue extensively (for any viewer, not just 3D) with PyQt5 to know if everything is working fine (there hasn't been much user testing on the Qt5 side)