### PR TITLE
Update Ginga to v2.6.0

### DIFF
--- a/ginga/meta.yaml
+++ b/ginga/meta.yaml
@@ -1,11 +1,10 @@
 {% set name = 'ginga' %}
-{% set version = '2.5.20161108122301' %}
-{% set rev = '79ea8d8' %}
+{% set version = 'v2.6.0' %}
 {% set number = '0' %}
 about:
     home: https://github.com/ejeschke/{{ name }}
     license: BSD
-    summary: FITS file viewer
+    summary: Astronomical data visualization
 build:
     number: {{ number }}
 package:
@@ -22,7 +21,7 @@ requirements:
     - numpy x.x
     - python x.x
 source:
-    git_rev: {{ rev }}
+    git_tag: {{ version }}
     git_url: https://github.com/ejeschke/{{ name }}.git
 test:
     commands:


### PR DESCRIPTION
Update Ginga to v2.6.0 (first GitHub release) -- https://github.com/ejeschke/ginga/releases/tag/v2.6.0