### PR TITLE
HSTCAL: Force gcc usage under OS X

### DIFF
--- a/hstcal/build.sh
+++ b/hstcal/build.sh
@@ -1,5 +1,7 @@
+if [[ `uname` == Darwin ]]; then
+    export CC=`which gcc`
+fi
 
-
-/usr/bin/python ./waf configure --destdir=$PREFIX
-/usr/bin/python ./waf build
-/usr/bin/python ./waf install
+./waf configure --destdir=$PREFIX
+./waf build
+./waf install

--- a/hstcal/meta.yaml
+++ b/hstcal/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'hstcal' %}
 {% set version = '1.1.1' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/spacetelescope/hstcal


### PR DESCRIPTION
@sosey discovered the HSTCAL build on OS X used `clang` instead of `gcc`, resulting in a segfault within `wfc3ir.e`.

This minor bump should take care of it.