### PR TITLE
[EXP] Add refactored synphot and stsynphot

### DIFF
--- a/stsynphot/bld.bat
+++ b/stsynphot/bld.bat
@@ -1,0 +1,2 @@
+python setup.py install || exit 1
+if errorlevel 1 exit 1

--- a/stsynphot/build.sh
+++ b/stsynphot/build.sh
@@ -1,0 +1,1 @@
+python setup.py install || exit 1

--- a/stsynphot/meta.yaml
+++ b/stsynphot/meta.yaml
@@ -1,0 +1,34 @@
+{% set reponame = 'stsynphot_refactor' %}
+{% set name = 'stsynphot' %}
+{% set version = '0.1b2' %}
+{% set number = '0' %}
+
+about:
+    home: https://github.com/spacetelescope/{{ reponame }}
+    license: BSD
+    summary: Synthetic photometry using Astropy for HST and JWST
+build:
+    number: {{ number }}
+package:
+    name: {{ name }}
+    version: {{ version }}
+requirements:
+    build:
+    - synphot >= 0.1
+    - astropy >=1.3
+    - scipy >= 0.14
+    - numpy x.x
+    - setuptools
+    - python x.x
+    run:
+    - synphot >= 0.1
+    - astropy >=1.3
+    - scipy >= 0.14
+    - numpy x.x
+    - python x.x
+source:
+    git_tag: {{ version }}
+    git_url: https://github.com/spacetelescope/{{ reponame }}.git
+test:
+    imports:
+    - stsynphot

--- a/synphot/bld.bat
+++ b/synphot/bld.bat
@@ -1,0 +1,2 @@
+python setup.py install || exit 1
+if errorlevel 1 exit 1

--- a/synphot/build.sh
+++ b/synphot/build.sh
@@ -1,0 +1,1 @@
+python setup.py install || exit 1

--- a/synphot/meta.yaml
+++ b/synphot/meta.yaml
@@ -1,6 +1,6 @@
 {% set reponame = 'synphot_refactor' %}
 {% set name = 'synphot' %}
-{% set version = '0.1b2' %}
+{% set version = '0.1b3' %}
 {% set number = '0' %}
 
 about:

--- a/synphot/meta.yaml
+++ b/synphot/meta.yaml
@@ -1,0 +1,32 @@
+{% set reponame = 'synphot_refactor' %}
+{% set name = 'synphot' %}
+{% set version = '0.1b2' %}
+{% set number = '0' %}
+
+about:
+    home: https://github.com/spacetelescope/{{ reponame }}
+    license: BSD
+    summary: Synthetic photometry using Astropy
+build:
+    number: {{ number }}
+package:
+    name: {{ name }}
+    version: {{ version }}
+requirements:
+    build:
+    - astropy >=1.3
+    - scipy >= 0.14
+    - numpy x.x
+    - setuptools
+    - python x.x
+    run:
+    - astropy >=1.3
+    - scipy >= 0.14
+    - numpy x.x
+    - python x.x
+source:
+    git_tag: {{ version }}
+    git_url: https://github.com/spacetelescope/{{ reponame }}.git
+test:
+    imports:
+    - synphot


### PR DESCRIPTION
Added recipes for Astropy version of PySynphot split into 2 packages: `synphot` and `stsynphot`

This requires Astropy 1.3. So, **do not merge** until AstroConda has that. Also, Joe, you should check that these actually can build, as `stsynphot` depends on `synphot` but I am adding both at the same time. They only have beta releases now but if beta does not work, then I can make a "stable" release.