### PR TITLE
ginga 2.6.1 (repair)

### DIFF
--- a/ginga/meta.yaml
+++ b/ginga/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = 'ginga' %}
-{% set version = 'v2.6.1' %}
+{% set version = '2.6.1' %}
+{% set tag = 'v' + version %}
 {% set number = '0' %}
 about:
     home: https://github.com/ejeschke/{{ name }}
@@ -13,15 +14,17 @@ package:
 requirements:
     build:
     - astropy >=1.2
+    - qtpy
     - setuptools
     - numpy x.x
     - python x.x
     run:
     - astropy >=1.2
+    - qtpy
     - numpy x.x
     - python x.x
 source:
-    git_tag: {{ version }}
+    git_tag: {{ tag }}
     git_url: https://github.com/ejeschke/{{ name }}.git
 test:
     commands:


### PR DESCRIPTION
Unable to build due to missing `qtpy` dependency. Also fixed the version data so the "v" prefix is no longer in the package name.