### PR TITLE
Bump stginga to 0.1.3

### DIFF
--- a/stginga/meta.yaml
+++ b/stginga/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stginga' %}
-{% set version = '0.1.2' %}
+{% set version = '0.1.3' %}
 {% set tag = version %}
 {% set number = '0' %}
 
@@ -14,14 +14,14 @@ package:
     version: {{ version }}
 requirements:
     build:
-    - ginga
+    - ginga >= 2.6.1
     - astropy >=1.2
     - numpy x.x
     - scipy
     - setuptools
     - python x.x
     run:
-    - ginga
+    - ginga >= 2.6.1
     - astropy >=1.2
     - numpy x.x
     - scipy


### PR DESCRIPTION
Bump `stginga` to 0.1.3 to be compatible with Ginga 2.6.1. Need this for AAS workshop on Jan 3, 2017.

Joe, do I need to add a "v" to the version? I am not sure if this should have the same convention as #128 or not.