### PR TITLE
Bump stsci.tools to 3.4.3

### DIFF
--- a/stsci.tools/meta.yaml
+++ b/stsci.tools/meta.yaml
@@ -7,7 +7,7 @@ build:
     preserve_egg_dir: 'yes'
 package:
     name: stsci.tools
-    version: 3.4.2.1
+    version: 3.4.3
 requirements:
     build:
     - d2to1


### PR DESCRIPTION
Bump `stsci.tools` to 3.4.3 to fix spacetelescope/stsci.tools#11

c/c @cdsontag