### PR TITLE
Remove duplicated packages from stsci metapackage

### DIFF
--- a/stsci/meta.yaml
+++ b/stsci/meta.yaml
@@ -24,8 +24,6 @@ requirements:
     - ds9 >=7.1
     - fftw >=3.3.4
     - htc_utils >=0.1
-    - imexam >=0.5.2
-    - photutils >=0.2.1
     - purge_path >=1.0.0
     - pyds9 >=1.8.1
     - pyfftw >=0.9.2
@@ -40,8 +38,6 @@ requirements:
     - ds9 >=7.1
     - fftw >=3.3.4
     - htc_utils >=0.1
-    - imexam >=0.5.2
-    - photutils >=0.2.1
     - purge_path >=1.0.0
     - pyds9 >=1.8.1
     - pyfftw >=0.9.2


### PR DESCRIPTION
The `stsci` metapackage predates `stsci-data-analysis`, so we had `imexam` and `photutils` defined in two places. We're removing them from the top-level and letting the proper metapackage manage them from now on.
