### PR TITLE
Update sphere 1.0.7 -> 1.0.10

### DIFF
--- a/sphere/meta.yaml
+++ b/sphere/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'sphere' %}
-{% set version = '1.0.7' %}
-{% set number = '1' %}
+{% set version = '1.0.10' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}


### PR DESCRIPTION
Must update 1.0.10 to fix python 3.5 compilation failure on build system.