### PR TITLE
webbpsf-data: Fix broken URL

### DIFF
--- a/webbpsf-data/meta.yaml
+++ b/webbpsf-data/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'webbpsf-data' %}
-{% set version = 0.5.0 %}
+{% set version = '0.5.0' %}
 {% set number = '0' %}
 
 about:
@@ -16,4 +16,4 @@ package:
 
 source:
     fn: {{ name }}-{{ version }}.tar.gz
-    url: http://www.stsci.edu/~mperrin/software/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    url: http://www.stsci.edu/~mperrin/software/webbpsf/{{ name }}-{{ version }}.tar.gz


### PR DESCRIPTION
(Not bumping the build revision -- data already exists in astroconda -- this problem was introduced by the overhaul)