### PR TITLE
Update stsci.tools 3.4.2.1 -> 3.4.3

### DIFF
--- a/stsci.tools/meta.yaml
+++ b/stsci.tools/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'stsci.tools' %}
-{% set version = '3.4.2.1' %}
-{% set number = '1' %}
+{% set version = '3.4.3' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/stsci.tools


### PR DESCRIPTION
Supersedes #132 

Bump `stsci.tools` to 3.4.3 to fix spacetelescope/stsci.tools#11
