### PR TITLE
Removes spaces between version specifiers

### DIFF
--- a/stsynphot/meta.yaml
+++ b/stsynphot/meta.yaml
@@ -7,34 +7,34 @@ about:
     home: https://github.com/spacetelescope/{{ reponame }}
     license: BSD
     summary: Synthetic photometry using Astropy for HST and JWST
-    
+
 build:
     number: {{ number }}
-    
+
 package:
     name: {{ name }}
     version: {{ version }}
 
 requirements:
     build:
-    - synphot >= 0.1
+    - synphot >=0.1
     - astropy >=1.3
-    - scipy >= 0.14
+    - scipy >=0.14
     - numpy
     - setuptools
     - python x.x
 
     run:
-    - synphot >= 0.1
+    - synphot >=0.1
     - astropy >=1.3
-    - scipy >= 0.14
+    - scipy >=0.14
     - numpy
     - python x.x
-    
+
 source:
     git_tag: {{ version }}
     git_url: https://github.com/spacetelescope/{{ reponame }}.git
-    
+
 test:
     imports:
     - stsynphot

--- a/synphot/meta.yaml
+++ b/synphot/meta.yaml
@@ -18,13 +18,13 @@ package:
 requirements:
     build:
     - astropy >=1.3
-    - scipy >= 0.14
+    - scipy >=0.14
     - numpy
     - setuptools
     - python x.x
     run:
     - astropy >=1.3
-    - scipy >= 0.14
+    - scipy >=0.14
     - numpy
     - python x.x
 


### PR DESCRIPTION
Invalid syntax:
`package >= 1.2.3`

Proper syntax:
`package >=1.2.3`