### PR TITLE
Fix resolver failure on "b" suffix.

### DIFF
--- a/stsynphot/meta.yaml
+++ b/stsynphot/meta.yaml
@@ -17,7 +17,7 @@ package:
 
 requirements:
     build:
-    - synphot >=0.1
+    - synphot >=0.1*
     - astropy >=1.3
     - scipy >=0.14
     - numpy
@@ -25,7 +25,7 @@ requirements:
     - python x.x
 
     run:
-    - synphot >=0.1
+    - synphot >=0.1*
     - astropy >=1.3
     - scipy >=0.14
     - numpy

--- a/synphot/meta.yaml
+++ b/synphot/meta.yaml
@@ -7,10 +7,10 @@ about:
     home: https://github.com/spacetelescope/{{ reponame }}
     license: BSD
     summary: Synthetic photometry using Astropy
-    
+
 build:
     number: {{ number }}
-    
+
 package:
     name: {{ name }}
     version: {{ version }}


### PR DESCRIPTION
Resolver could not find `synphot >=0.1` due to the tag suffix `b2`. Appending a wildcard to the version specifier fixes the issue: `synphot >=0.1*`

@pllim fyi