### PR TITLE
Compile ds9 without libXss dependency on Linux & update to v7.5

### DIFF
--- a/ds9/build.sh
+++ b/ds9/build.sh
@@ -14,7 +14,7 @@ exit 1
 ;;
 esac
 
-unix/configure
+unix/configure TKFLAGS="--disable-xss"  # not all machines have libXss
 make
 mkdir -p $PREFIX/bin
 cp -a bin/ds9* bin/x* $PREFIX/bin

--- a/ds9/meta.yaml
+++ b/ds9/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'ds9' %}
-{% set version = '7.4' %}
+{% set version = '7.5' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
This optional dependency is missing on some machines (eg. my laptop running CentOS 7 and other cases we have seen with Ureka) at run time. It still seems to get compiled against libXss on MacOS, but that shouldn't really matter.
