### PR TITLE
Bump stsci.tools to 3.4.4

### DIFF
--- a/stsci.tools/meta.yaml
+++ b/stsci.tools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.tools' %}
-{% set version = '3.4.3' %}
+{% set version = '3.4.4' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
To be compatible with Astropy 1.3 or later.