### PR TITLE
update imexam to v0.7.0

### DIFF
--- a/imexam/meta.yaml
+++ b/imexam/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'imexam' %}
-{% set version = '0.6.3' %}
+{% set version = '0.7.0' %}
 {% set tag = 'v' + version %}
 {% set number = '1' %}
 

--- a/imexam/meta.yaml
+++ b/imexam/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'imexam' %}
 {% set version = '0.7.0' %}
 {% set tag = 'v' + version %}
-{% set number = '1' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}


### PR DESCRIPTION
This new release fixes a couple bugs, update xpa to v.2.1.18 and allows windows users to build without DS9 (Ginga is the viewer subsitute, or it can be used for command line interaction and making plots)