### PR TITLE
Bumped stsci.tools to 3.4.5

### DIFF
--- a/stsci.tools/meta.yaml
+++ b/stsci.tools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.tools' %}
-{% set version = '3.4.4' %}
+{% set version = '3.4.5' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
To avoid deprecation warnings from astropy >= 1.3