### PR TITLE
jwst_gtvt -> 0.0.2

### DIFF
--- a/jwst_gtvt/meta.yaml
+++ b/jwst_gtvt/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'jwst_gtvt' %}
-{% set version = '0.0.1' %}
+{% set version = '0.0.2' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Should fix circular import error detected in the Python 2.7 build.