### PR TITLE
Bump acstools to 2.0.7

### DIFF
--- a/acstools/meta.yaml
+++ b/acstools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'acstools' %}
-{% set version = '2.0.6' %}
+{% set version = '2.0.7' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
To fix TypeError in regression test due to Numpy 1.12 indexing.

This fixes spacetelescope/acstools#20