### PR TITLE
Add missing python requirements

### DIFF
--- a/stsci_sphinx_theme/meta.yaml
+++ b/stsci_sphinx_theme/meta.yaml
@@ -17,9 +17,12 @@ source:
 requirements:
   build:
     - sphinx >=1.1
+    - setuptools
+    - python x.x
 
   run:
     - sphinx >=1.1
+    - python x.x
 
 test:
   requires:


### PR DESCRIPTION
Without `setuptools` conda-build conveniently chooses the ROOT environment's `setuptools`. Gotta love it.

Without `python x.x` conda-build does a similar thing.

Winning all around.