### PR TITLE
Add glue-ginga package to the channel

### DIFF
--- a/glue-ginga/bld.bat
+++ b/glue-ginga/bld.bat
@@ -1,0 +1,3 @@
+
+python setup.py install
+if errorlevel 1 exit 1

--- a/glue-ginga/bld.bat
+++ b/glue-ginga/bld.bat
@@ -1,3 +1,2 @@
-
-python setup.py install
+%PYTHON% setup.py install
 if errorlevel 1 exit 1

--- a/glue-ginga/build.sh
+++ b/glue-ginga/build.sh
@@ -1,0 +1,3 @@
+
+echo > README.rst
+python setup.py install || exit 1

--- a/glue-ginga/build.sh
+++ b/glue-ginga/build.sh
@@ -1,3 +1,2 @@
-
 echo > README.rst
-python setup.py install || exit 1
+$PYTHON setup.py install || exit 1

--- a/glue-ginga/meta.yaml
+++ b/glue-ginga/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = 'glue-ginga' %}
+{% set version = '0.1.1' %}
+{% set tag = 'v' + version %}
+{% set number = '0' %}
+
+about:
+    home: https://github.com/ejeschke/{{ name }}
+    license: BSD
+    summary: Astronomical data visualization
+
+build:
+    number: {{ number }}
+
+package:
+    name: {{ name }}
+    version: {{ version }}
+
+requirements:
+    build:
+    - astropy >=1.2
+    - glueviz >=0.10
+    - ginga >=2.6.1
+    - setuptools
+    - numpy
+    - python x.x
+    run:
+    - astropy >=1.2
+    - glueviz >=0.10
+    - ginga >=2.6.1
+    - numpy
+    - python x.x
+
+source:
+    git_tag: {{ tag }}
+    git_url: https://github.com/ejeschke/{{ name }}.git
+
+test:
+    imports:
+    - glue_ginga


### PR DESCRIPTION
Add `glue-ginga` package to the channel. This enables bridging between Glue and Ginga; that is, user can send data between the two software.

See https://github.com/ejeschke/glue-ginga/releases/tag/v0.1.1

c/c @ejeschke @astrofrog 

@jhunkeler , I am not 100% sure if the dependency listing would work properly, please test. Thanks!