### PR TITLE
Quick fix for Ginga

### DIFF
--- a/ginga/meta.yaml
+++ b/ginga/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'ginga' %}
-{% set version = '2.6.2' %}
-{% set tag = 'v' + version %}
-{% set number = '0' %}
+{% set version = '2.6.2.1' %}
+{% set tag = 'ab017d8' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/ejeschke/{{ name }}


### PR DESCRIPTION
So it would work with `stginga`. This is basically pinning Ginga to latest dev as of today. There is not actually a real 2.6.2.1 release. @jhunkeler , is this the correct way to do such a thing?