### PR TITLE
Fix vispy viewers

### DIFF
--- a/glue-vispy-viewers/bld.bat
+++ b/glue-vispy-viewers/bld.bat
@@ -1,0 +1,1 @@
+%PYTHON% setup.py install

--- a/glue-vispy-viewers/build.sh
+++ b/glue-vispy-viewers/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py install

--- a/glue-vispy-viewers/meta.yaml
+++ b/glue-vispy-viewers/meta.yaml
@@ -13,27 +13,31 @@ source:
 
 build:
   number: {{ number }}
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  preserve_egg_dir: True
 
 requirements:
+    build:
+      - astropy
+      - glueviz >=0.10
+      - scikit-image
+      - qtpy
+      - python x.x
+      - setuptools
 
-  build:
-    - python
-    - setuptools
+    run:
+      - astropy
+      - numpy
+      - pyopengl
+      - glueviz >=0.10
+      - scikit-image
+      - matplotlib
+      - qtpy
+      - pyqt
+      - python x.x
 
-run:
-    - python
-    - numpy
-    - pyopengl
-    - glueviz >=0.10
-    - scikit-image
-    - matplotlib
-    - qtpy
-    - pyqt
-
-    # Temporary: the scikit-image conda package is missing the dask dependency
-    # so we add it here for now
-    - dask
+      # Temporary: the scikit-image conda package is missing the dask dependency
+      # so we add it here for now
+      - dask
 
 test:
   imports:

--- a/glue-vispy-viewers/meta.yaml
+++ b/glue-vispy-viewers/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'glue-vispy-viewers' %}
-{% set version = "0.7.1" %}
-{% set number = '0' %}
+{% set version = '0.7.1' %}
+{% set number = '1' %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
The inconsistent spaces in the recipe were throwing conda-build into a frenzy. `script: python setup.py install --single-version-externally-managed --record record.txt` seemed to be causing additional problems with conda's dependency resolution, so I removed it and added individual scripts.

What was added to `requirements/build` are the truly the bare minimum required to successfully compile this package. I don't recommend removing them.

BTW `preserve_egg_dir` acts much like `--single-version-externally-managed --record record.txt`, except for conda can actually track what's going on.
