### PR TITLE
Updates for glue

### DIFF
--- a/glue-core/LICENSE
+++ b/glue-core/LICENSE
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/glue-core/meta.yaml
+++ b/glue-core/meta.yaml
@@ -1,0 +1,77 @@
+{% set name = 'glue-core' %}
+{% set version = '0.10.1' %}
+{% set number = '0' %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/g/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  md5: bf0d8d2c2fba069d554aadb9acce5292
+
+build:
+  number: {{ number }}
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  entry_points:
+    - glue = glue.main:main
+    - glue-config = glue.config_gen:main
+    - glue-deps = glue._deps:main
+  osx_is_app: True
+
+requirements:
+
+  build:
+    - python
+    - setuptools
+    - pyqt
+
+  run:
+
+    # The following is needed to make sure that the package works as a GUI
+    # application (glue needs to be run with python.app, not python)
+    - python.app  # [osx]
+
+    # Required dependencies
+    - python
+    - numpy >=1.9
+    - pandas >=0.14
+    - astropy >=1.3
+    - matplotlib >=1.4
+    - qtpy >=1.1.1
+    - ipython >=4.0
+    - ipykernel
+    - qtconsole
+    - dill >=0.2
+    - xlrd >=1.0
+    - h5py >=2.4
+    - setuptools >=1.0
+    - pyqt
+
+    # Optional dependencies (defined in ``extras_require``)
+    - scipy
+    - scikit-image
+    - plotly
+
+    # Temporary: the scikit-image conda package is missing the dask dependency
+    # so we add it here for now
+    - dask
+
+test:
+  imports:
+    - glue
+    - glue.core
+    - glue.app.qt
+  commands:
+    - glue --version
+    - glue-deps list
+
+# NOTE: we deliberatey do NOT include an app entry here, because we instead do this
+# in the glueviz meta-package (we don't want glue to appear twice in the navigator)
+
+about:
+  home: http://glueviz.org
+  license: BSD 3-Clause
+  license_file: LICENSE
+  summary: Multi-dimensional linked data exploration

--- a/glue-vispy-viewers/meta.yaml
+++ b/glue-vispy-viewers/meta.yaml
@@ -16,10 +16,12 @@ build:
   preserve_egg_dir: True
 
 requirements:
-
   build:
     - python
     - setuptools
+    - numpy
+    - pyopengl
+    - glue-core >=0.10
 
   run:
     - python

--- a/glue-vispy-viewers/meta.yaml
+++ b/glue-vispy-viewers/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'glue-vispy-viewers' %}
-{% set version = '0.7.1' %}
-{% set number = '2' %}
+{% set version = "0.7.2" %}
+{% set number = '0' %}
 
 package:
   name: {{ name }}
@@ -9,36 +9,26 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/g/glue-vispy-viewers/{{ name }}-{{ version }}.tar.gz
-  md5: 2189493a5070024ff3c412307a6a5a7e
+  md5: 58cd60967ed1b80b965b0627b2d3bd77
 
 build:
   number: {{ number }}
   preserve_egg_dir: True
 
 requirements:
-    build:
-      - astropy
-      - glueviz >=0.10
-      - scikit-image
-      - qtpy
-      - python x.x
-      - setuptools
-      - pyopengl
 
-    run:
-      - astropy
-      - numpy
-      - pyopengl
-      - glueviz >=0.10
-      - scikit-image
-      - matplotlib
-      - qtpy
-      - pyqt
-      - python x.x
+  build:
+    - python
+    - setuptools
 
-      # Temporary: the scikit-image conda package is missing the dask dependency
-      # so we add it here for now
-      - dask
+  run:
+    - python
+    - numpy
+    - pyopengl
+    - glue-core >=0.10
+    - matplotlib
+    - qtpy
+    - pyqt
 
 test:
   imports:

--- a/glueviz/meta.yaml
+++ b/glueviz/meta.yaml
@@ -1,5 +1,9 @@
+# NOTE: this is a meta-package that includes the core glue code as well as stable
+# plugins. This is the main conda package we want in the Navigator, so we add the
+# app: entry here and not in the glue-core package.
+
 {% set name = 'glueviz' %}
-{% set version = '0.10.0' %}
+{% set version = '0.10.1' %}
 {% set number = '0' %}
 
 package:
@@ -9,54 +13,20 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/g/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: 1bdd8b6925fb028938ee3affd7b95059
+  md5: abcb117e102ae9cb00c5dd1bd784c5f3
 
 build:
   number: {{ number }}
-  script: python setup.py install --single-version-externally-managed --record record.txt
-  entry_points:
-    - glue = glue.main:main
-    - glue-config = glue.config_gen:main
-    - glue-deps = glue._deps:main
-  osx_is_app: True
 
 requirements:
 
   build:
     - python
     - setuptools
-    - pyqt
 
   run:
-
-    # The following is needed to make sure that the package works as a GUI
-    # application (glue needs to be run with python.app, not python)
-    - python.app  # [osx]
-
-    # Required dependencies
-    - python
-    - numpy >=1.9
-    - pandas >=0.14
-    - astropy >=1.3
-    - matplotlib >=1.4
-    - qtpy >=1.1.1
-    - ipython >=4.0
-    - ipykernel
-    - qtconsole
-    - dill >=0.2
-    - xlrd >=1.0
-    - h5py >=2.4
-    - setuptools >=1.0
-    - pyqt
-
-    # Optional dependencies (defined in ``extras_require``)
-    - scipy
-    - scikit-image
-    - plotly
-
-    # Temporary: the scikit-image conda package is missing the dask dependency
-    # so we add it here for now
-    - dask
+    - glue-core >=0.10.1
+    - glue-vispy-viewers >=0.7.2
 
 test:
   imports:
@@ -76,5 +46,5 @@ app:
 about:
   home: http://glueviz.org
   license: BSD 3-Clause
-  license_file: LICENSE
+  #license_file: LICENSE
   summary: Multi-dimensional linked data exploration

--- a/glueviz/meta.yaml
+++ b/glueviz/meta.yaml
@@ -10,33 +10,18 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/g/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: abcb117e102ae9cb00c5dd1bd784c5f3
-
 build:
   number: {{ number }}
 
 requirements:
-
   build:
     - python
     - setuptools
+    - glue-vispy-viewers >=0.7.2
 
   run:
-    - glue-core >=0.10.1
     - glue-vispy-viewers >=0.7.2
     - glue-ginga
-
-test:
-  imports:
-    - glue
-    - glue.core
-    - glue.app.qt
-  commands:
-    - glue --version
-    - glue-deps list
 
 app:
   entry: glue
@@ -47,5 +32,4 @@ app:
 about:
   home: http://glueviz.org
   license: BSD 3-Clause
-  #license_file: LICENSE
   summary: Multi-dimensional linked data exploration

--- a/glueviz/meta.yaml
+++ b/glueviz/meta.yaml
@@ -27,6 +27,7 @@ requirements:
   run:
     - glue-core >=0.10.1
     - glue-vispy-viewers >=0.7.2
+    - glue-ginga
 
 test:
   imports:


### PR DESCRIPTION
This updates the glue recipes to match the latest set-up - glueviz is now a metapackage that installs glue-core and stable plugins, which avoids circular dependencies.

The ``glue-core`` package should be built first since it doesn't yet exist, and it's needed for the glue-vispy-viewers package.