### PR TITLE
Update Astroquery to 0.3.5

### DIFF
--- a/astroquery/meta.yaml
+++ b/astroquery/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = 'astroquery' %}
-{% set version = '0.3.3' %}
+{% set version = '0.3.5' %}
 {% set number = '0' %}
 
 about:
-    home: https://github.com/spacetelescope/{{ name }}
+    home: https://github.com/astropy/{{ name }}
     license: BSD
     summary: Astroquery is a set of tools for querying astronomical web forms and databases.
 

--- a/astroquery/meta.yaml
+++ b/astroquery/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = 'astroquery' %}
 {% set version = '0.3.5' %}
+{% set tag = 'v' + version %}
 {% set number = '0' %}
 
 about:
@@ -12,9 +13,8 @@ package:
     version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/a/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: 1be83c630fcb462a711eb9c2eda0fbea
+    git_url: https://github.com/astropy/{{ name }}
+    git_tag: {{ tag }}
 
 build:
     number: {{ number }}
@@ -28,6 +28,7 @@ requirements:
     - html5lib
     - setuptools
     - python x.x
+    
     run:
     - astropy
     - requests


### PR DESCRIPTION
For when 0.3.5 is actually released (soon). It will have Cone Search then.

Not sure why it was pointing to `spacetelescope`, it is an Astropy-affilliated package. How did that happen? Also, the actual GitHub release has a "v" in version number...

Also not sure about the PyPi incantations, probably needs changing too?