### PR TITLE
Revert changes from HSTDP 2017.2

### DIFF
--- a/calcos/meta.yaml
+++ b/calcos/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'calcos' %}
-{% set version = '3.2.1' %}
-{% set number = '0' %}
+{% set version = '3.1.8' %}
+{% set number = '2' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}

--- a/crds/meta.yaml
+++ b/crds/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'crds' %}
-{% set version = '7.1.1' %}
+{% set version = '7.1.0' %}
 {% set number = '0' %}
 
 about:

--- a/drizzlepac/meta.yaml
+++ b/drizzlepac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'drizzlepac' %}
-{% set version = '2.1.14' %}
+{% set version = '2.1.13' %}
 {% set number = '0' %}
 
 about:

--- a/hstcal/meta.yaml
+++ b/hstcal/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'hstcal' %}
-{% set version = '1.2.0rc1' %}
-{% set number = '0' %}
+{% set version = '1.1.1' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}

--- a/stsci-hst/meta.yaml
+++ b/stsci-hst/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci-hst' %}
-{% set version = '3.0.0' %}
+{% set version = '2.0.0' %}
 {% set number = '0' %}
 
 about:
@@ -19,13 +19,13 @@ requirements:
     - purge_path >=1.0.0
     - acstools >=2.0.0
     - astropy >=1.1
-    - calcos >=3.2.1
+    - calcos >=3.1.8
     - costools >=1.2.1
-    - crds >=7.1.1
+    - crds >=7.0.1
     - d2to1 >=0.2.12
-    - drizzlepac >=2.1.14
+    - drizzlepac >=2.1.3
     - fitsblender >=0.2.6
-    - hstcal >=1.2.0rc1
+    - hstcal >=1.0.0
     - nictools >=1.1.3
     - pyregion >=1.1.2
     - pysynphot >=0.9.8.2
@@ -42,23 +42,23 @@ requirements:
     - stsci.stimage >=0.2.1
     - stsci.skypac >=0.9
     - stsci.sphere >=0.2
-    - stsci.tools >=3.4.9
-    - stwcs >=1.3.2rc1
+    - stsci.tools >=3.4.1
+    - stwcs >=1.2.3
     - wfpc2tools >=1.0.3
-    - wfc3tools >=1.3.5rc1
+    - wfc3tools >=1.3.1
     - numpy
     - python x.x
     run:
     - purge_path >=1.0.0
     - acstools >=2.0.0
     - astropy >=1.1
-    - calcos >=3.2.1
+    - calcos >=3.1.8
     - costools >=1.2.1
-    - crds >=7.1.1
+    - crds >=7.0.1
     - d2to1 >=0.2.12
-    - drizzlepac >=2.1.14
+    - drizzlepac >=2.1.3
     - fitsblender >=0.2.6
-    - hstcal >=1.2.0rc1
+    - hstcal >=1.0.0
     - nictools >=1.1.3
     - pyregion >=1.1.2
     - pysynphot >=0.9.8.2
@@ -75,9 +75,9 @@ requirements:
     - stsci.stimage >=0.2.1
     - stsci.skypac >=0.9
     - stsci.sphere >=0.2
-    - stsci.tools >=3.4.9
-    - stwcs >=1.3.2rc1
+    - stsci.tools >=3.4.1
+    - stwcs >=1.2.3
     - wfpc2tools >=1.0.3
-    - wfc3tools >=1.3.5rc1
+    - wfc3tools >=1.3.1
     - numpy
     - python x.x

--- a/stsci.tools/meta.yaml
+++ b/stsci.tools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.tools' %}
-{% set version = '3.4.9' %}
+{% set version = '3.4.7' %}
 {% set number = '0' %}
 
 about:

--- a/stwcs/meta.yaml
+++ b/stwcs/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'stwcs' %}
-{% set version = '1.3.2rc1' %}
-{% set number = '0' %}
+{% set version = '1.2.5' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}

--- a/wfc3tools/meta.yaml
+++ b/wfc3tools/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'wfc3tools' %}
-{% set version = '1.3.5rc1' %}
-{% set number = '0' %}
+{% set version = '1.3.4' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}


### PR DESCRIPTION
Rolling back recipe changes to prevent automatic rebuilding and publication of errant packages created as part of the preparation for the HSTDP 2017.2 build, first iteration.