### PR TITLE
parsley: Fix package naming typo

### DIFF
--- a/parsley/meta.yaml
+++ b/parsley/meta.yaml
@@ -1,11 +1,13 @@
-{% set name = 'parsely' %}
+{% set name = 'parsley' %}
+{% set badname = 'Parsley' %}
 {% set version = '1.3' %}
 {% set number = '0' %}
 
 about:
-    home: https://pypi.python.org/packages/source/P/Parsley
+    home: https://pypi.python.org/packages/source/P/{{ badname }}
     license: BSD
-    summary: parsley
+    summary: |
+        Parsley is a parsing library for people who find parsers scary or annoying
 
 build:
     number: {{ number }}
@@ -24,7 +26,7 @@ requirements:
 source:
     fn: Parsley-{{ version }}.tar.gz
     md5: 92bc256e5f73810a609dc7874637ad31
-    url: https://pypi.python.org/packages/source/P/Parsley/Parsley-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/P/{{ badname }}/{{ badname }}-{{ version }}.tar.gz
 
 test:
     imports:


### PR DESCRIPTION
Corrected: `name = 'parsely'`
It would have helped to spell it right.