### PR TITLE
CRDS: Add optional dependencies; bump build

### DIFF
--- a/crds/build.sh
+++ b/crds/build.sh
@@ -1,4 +1,1 @@
-
-
-pip install --no-deps --upgrade --force d2to1 || exit 1
-python setup.py install || exit 1
+python setup.py install

--- a/crds/meta.yaml
+++ b/crds/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'crds' %}
 {% set version = '7.1.0' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: http://www.stsci.edu/hst/observatory/crds/
@@ -19,20 +19,25 @@ package:
 
 requirements:
     build:
-    - d2to1
     - astropy >=1.1
+    - cfitsio
     - numpy
+    - requests
+    - lxml
+    - parsley
     - setuptools
     - python x.x
-    - requests
-    - lxml
+
     run:
     - astropy >=1.1
+    - cfitsio
     - numpy
-    - python x.x
     - requests
     - lxml
-    
+    - fitsverify
+    - parsley
+    - python x.x
+
 source:
     git_tag: {{ version }}
     git_url: https://github.com/spacetelescope/{{ name }}.git


### PR DESCRIPTION
The new dependencies are not used except under certain specific circumstances. General users will not notice a difference.