### PR TITLE
Release drizzlepac 2.1.15

### DIFF
--- a/drizzlepac/meta.yaml
+++ b/drizzlepac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'drizzlepac' %}
-{% set version = '2.1.13' %}
+{% set version = '2.1.15' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Includes the following improvements:
- WCS merge logic for output WCS computations: https://github.com/spacetelescope/drizzlepac/pull/65
- addition of ``crpix1`` and ``crpix2`` parameters to TEAL for custom WCS: https://github.com/spacetelescope/drizzlepac/pull/66
- turned off memory mapping: https://github.com/spacetelescope/drizzlepac/pull/67
- updated release notes and ``htmlhelp``: https://github.com/spacetelescope/drizzlepac/pull/68

CC: @jhunkeler @rendinam