### PR TITLE
Update glue-core and glueviz to 0.10.4

### DIFF
--- a/glue-core/meta.yaml
+++ b/glue-core/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'glue-core' %}
-{% set version = '0.10.1' %}
+{% set version = '0.10.4' %}
 {% set number = '0' %}
 
 package:
@@ -9,7 +9,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/g/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: bf0d8d2c2fba069d554aadb9acce5292
+  md5: def1af4db51dc6e0a79bb24539f4c633
 
 build:
   number: {{ number }}

--- a/glue-vispy-viewers/bld.bat
+++ b/glue-vispy-viewers/bld.bat
@@ -1,1 +1,0 @@
-%PYTHON% setup.py install

--- a/glue-vispy-viewers/build.sh
+++ b/glue-vispy-viewers/build.sh
@@ -1,1 +1,0 @@
-$PYTHON setup.py install

--- a/glue-vispy-viewers/meta.yaml
+++ b/glue-vispy-viewers/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: {{ number }}
+  script: python setup.py install --single-version-externally-managed --record record.txt
   preserve_egg_dir: True
 
 requirements:

--- a/glueviz/meta.yaml
+++ b/glueviz/meta.yaml
@@ -3,7 +3,7 @@
 # app: entry here and not in the glue-core package.
 
 {% set name = 'glueviz' %}
-{% set version = '0.10.1' %}
+{% set version = '0.10.4' %}
 {% set number = '0' %}
 
 package:
@@ -12,14 +12,18 @@ package:
 
 build:
   number: {{ number }}
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
     - setuptools
+    - glue-core >=0.10.4
     - glue-vispy-viewers >=0.7.2
+    - glue-ginga
 
   run:
+    - glue-core >=0.10.4
     - glue-vispy-viewers >=0.7.2
     - glue-ginga
 


### PR DESCRIPTION
I added back glue-core as a dependency to glueviz - I don't have any issues when building locally, and glue-core definitely needs to be in the glueviz dependencies otherwise we might run into issues if glue-core is removed or downgraded for example.