### PR TITLE
Bump drizzlepac release to 2.1.16

### DIFF
--- a/drizzlepac/meta.yaml
+++ b/drizzlepac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'drizzlepac' %}
-{% set version = '2.1.15' %}
+{% set version = '2.1.16' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Includes a fix for a bug in the mergeWCS logic due to which custom (=user specified) WCS scale parameter was ignored. See https://github.com/spacetelescope/drizzlepac/pull/69 for more details.