### PR TITLE
parsley: truncate README

### DIFF
--- a/parsley/build.sh
+++ b/parsley/build.sh
@@ -1,2 +1,2 @@
-
-python setup.py install || exit 1
+echo > README
+python setup.py install


### PR DESCRIPTION
README contains unicode characters and causes the build to fail on Linux. OS X seems to breeze through it.