### PR TITLE
Make stsci.tools a depedency of acstools

### DIFF
--- a/acstools/meta.yaml
+++ b/acstools/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'acstools' %}
 {% set version = '2.0.7' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}

--- a/acstools/meta.yaml
+++ b/acstools/meta.yaml
@@ -14,11 +14,13 @@ package:
 requirements:
     build:
     - astropy >=1.1
+    - stsci.tools
     - numpy
     - setuptools
     - python x.x
     run:
     - astropy >=1.1
+    - stsci.tools
     - numpy
     - python x.x
 source:


### PR DESCRIPTION
Strictly speaking, `stsci.tools` is optional dependency because it is only used in *some* tasks in `acstools` but it is required for `acs_destripe_plus`, which is quite popular for people who use this package, so might as well just make it a dependency here to avoid resultant help calls.