### PR TITLE
Correct ripples from glue-related package shuffle

### DIFF
--- a/glue-ginga/meta.yaml
+++ b/glue-ginga/meta.yaml
@@ -17,6 +17,7 @@ package:
 
 requirements:
     build:
+    - scipy
     - astropy >=1.2
     - glueviz >=0.10
     - ginga >=2.6.1
@@ -24,6 +25,7 @@ requirements:
     - numpy
     - python x.x
     run:
+    - scipy
     - astropy >=1.2
     - glueviz >=0.10
     - ginga >=2.6.1

--- a/mosviz/build.sh
+++ b/mosviz/build.sh
@@ -1,1 +1,5 @@
+# Remove reference to glueviz from setup script, since this breaks the build
+# as there is no file containing 'glueviz' produced for that package since
+# glueviz has become a metapackage.
+sed -i -e "/'glueviz.*',$/d" setup.py
 $PYTHON setup.py install


### PR DESCRIPTION
* Adjust mosviz/setup.py on the fly to allow successful build
* Add missing dependency to glue-ginga