### PR TITLE
HSTDP 2017.2

### DIFF
--- a/acstools/meta.yaml
+++ b/acstools/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'acstools' %}
-{% set version = '2.0.7' %}
-{% set number = '1' %}
+{% set version = '2.0.8' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}

--- a/calcos/meta.yaml
+++ b/calcos/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'calcos' %}
-{% set version = '3.1.8' %}
-{% set number = '2' %}
+{% set version = '3.2.1' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}

--- a/drizzlepac/meta.yaml
+++ b/drizzlepac/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'drizzlepac' %}
-{% set version = '2.1.16' %}
-{% set number = '1' %}
+{% set version = '2.1.17' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}

--- a/fitsblender/meta.yaml
+++ b/fitsblender/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'fitsblender' %}
-{% set version = '0.3.1' %}
+{% set version = '0.3.2' %}
 {% set number = '0' %}
 
 about:

--- a/hstcal/meta.yaml
+++ b/hstcal/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'hstcal' %}
-{% set version = '1.1.1' %}
-{% set number = '1' %}
+{% set version = '1.2.0' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}

--- a/pysynphot/meta.yaml
+++ b/pysynphot/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'pysynphot' %}
-{% set version = '0.9.8.6' %}
+{% set version = '0.9.8.7' %}
 {% set number = '0' %}
 
 about:

--- a/stsci-data-analysis/meta.yaml
+++ b/stsci-data-analysis/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci-data-analysis' %}
-{% set version = '2.0.1' %}
+{% set version = '2.0.2' %}
 {% set number = '0' %}
 
 about:
@@ -16,11 +16,11 @@ package:
 
 requirements:
     build:
-    - astropy >=1.1
+    - astropy >=1.3
     - astroimtools >=0.1
     - stginga >=0.1
     - specviz >=0.2.3
-    - mosviz
+    #- mosviz
     - photutils >=0.2.2
     - glueviz >=0.9.0
     - imexam >=0.6.2
@@ -28,11 +28,11 @@ requirements:
     - numpy
     - python x.x
     run:
-    - astropy >=1.1
+    - astropy >=1.3
     - astroimtools >=0.1
     - stginga >=0.1
     - specviz >=0.2.3
-    - mosviz
+    #- mosviz
     - photutils >=0.2.2
     - glueviz >=0.9.0
     - imexam >=0.6.2

--- a/stsci-hst/meta.yaml
+++ b/stsci-hst/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci-hst' %}
-{% set version = '2.0.0' %}
+{% set version = '3.0.0' %}
 {% set number = '0' %}
 
 about:
@@ -17,21 +17,21 @@ package:
 requirements:
     build:
     - purge_path >=1.0.0
-    - acstools >=2.0.0
-    - astropy >=1.1
-    - calcos >=3.1.8
+    - acstools >=2.0.8
+    - astropy >=1.3
+    - calcos >=3.2.1
     - costools >=1.2.1
-    - crds >=7.0.1
+    - crds >=7.1.1
     - d2to1 >=0.2.12
-    - drizzlepac >=2.1.3
-    - fitsblender >=0.2.6
-    - hstcal >=1.0.0
+    - drizzlepac >=2.1.17
+    - fitsblender >=0.3.2
+    - hstcal >=1.2.0
     - nictools >=1.1.3
     - pyregion >=1.1.2
-    - pysynphot >=0.9.8.2
-    - reftools >=1.7.1
+    - pysynphot >=0.9.8.7
+    - reftools >=1.7.4
     - stistools >=1.1
-    - stsci.convolve >=2.1.3
+    - stsci.convolve >=2.2.1
     - stsci.distutils >=0.3.8
     - stsci.image >=2.2.0
     - stsci.imagemanip >=1.1.2
@@ -42,29 +42,29 @@ requirements:
     - stsci.stimage >=0.2.1
     - stsci.skypac >=0.9
     - stsci.sphere >=0.2
-    - stsci.tools >=3.4.1
-    - stwcs >=1.2.3
+    - stsci.tools >=3.4.11
+    - stwcs >=1.3.2
     - wfpc2tools >=1.0.3
     - wfc3tools >=1.3.1
     - numpy
     - python x.x
     run:
     - purge_path >=1.0.0
-    - acstools >=2.0.0
-    - astropy >=1.1
-    - calcos >=3.1.8
+    - acstools >=2.0.8
+    - astropy >=1.3
+    - calcos >=3.2.1
     - costools >=1.2.1
-    - crds >=7.0.1
+    - crds >=7.1.1
     - d2to1 >=0.2.12
-    - drizzlepac >=2.1.3
-    - fitsblender >=0.2.6
-    - hstcal >=1.0.0
+    - drizzlepac >=2.1.17
+    - fitsblender >=0.3.2
+    - hstcal >=1.2.0
     - nictools >=1.1.3
     - pyregion >=1.1.2
-    - pysynphot >=0.9.8.2
-    - reftools >=1.7.1
+    - pysynphot >=0.9.8.7
+    - reftools >=1.7.4
     - stistools >=1.1
-    - stsci.convolve >=2.1.3
+    - stsci.convolve >=2.2.1
     - stsci.distutils >=0.3.8
     - stsci.image >=2.2.0
     - stsci.imagemanip >=1.1.2
@@ -75,7 +75,7 @@ requirements:
     - stsci.stimage >=0.2.1
     - stsci.skypac >=0.9
     - stsci.sphere >=0.2
-    - stsci.tools >=3.4.1
+    - stsci.tools >=3.4.11
     - stwcs >=1.2.3
     - wfpc2tools >=1.0.3
     - wfc3tools >=1.3.1

--- a/stsci-hst/meta.yaml
+++ b/stsci-hst/meta.yaml
@@ -76,7 +76,7 @@ requirements:
     - stsci.skypac >=0.9
     - stsci.sphere >=0.2
     - stsci.tools >=3.4.11
-    - stwcs >=1.2.3
+    - stwcs >=1.3.2
     - wfpc2tools >=1.0.3
     - wfc3tools >=1.3.1
     - numpy

--- a/stsci-hst/meta.yaml
+++ b/stsci-hst/meta.yaml
@@ -40,12 +40,12 @@ requirements:
     - stsci.numdisplay >=1.6.1
     - stsci.sphinxext >=1.2.2
     - stsci.stimage >=0.2.1
-    - stsci.skypac >=0.9
+    - stsci.skypac >=0.9.5
     - stsci.sphere >=0.2
     - stsci.tools >=3.4.11
     - stwcs >=1.3.2
     - wfpc2tools >=1.0.3
-    - wfc3tools >=1.3.1
+    - wfc3tools >=1.3.4
     - numpy
     - python x.x
     run:
@@ -73,11 +73,11 @@ requirements:
     - stsci.numdisplay >=1.6.1
     - stsci.sphinxext >=1.2.2
     - stsci.stimage >=0.2.1
-    - stsci.skypac >=0.9
+    - stsci.skypac >=0.9.5
     - stsci.sphere >=0.2
     - stsci.tools >=3.4.11
     - stwcs >=1.3.2
     - wfpc2tools >=1.0.3
-    - wfc3tools >=1.3.1
+    - wfc3tools >=1.3.4
     - numpy
     - python x.x

--- a/stsci-hst/meta.yaml
+++ b/stsci-hst/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'stsci-hst' %}
 {% set version = '3.0.0' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: http://ssb.stsci.edu

--- a/stsci.tools/meta.yaml
+++ b/stsci.tools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.tools' %}
-{% set version = '3.4.10' %}
+{% set version = '3.4.11' %}
 {% set number = '0' %}
 
 about:

--- a/stsci/meta.yaml
+++ b/stsci/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci' %}
-{% set version = '2.0.0' %}
+{% set version = '3.0.0' %}
 {% set number = '0' %}
 
 about:
@@ -16,9 +16,9 @@ package:
 
 requirements:
     build:
-    - stsci-hst
-    - stsci-data-analysis
-    - astropy >=1.1
+    - stsci-hst >=3.0.0
+    - stsci-data-analysis >=2.0.2
+    - astropy >=1.3
     - cfitsio >=3.370
     - d2to1 >=0.2.12
     - ds9 >=7.1
@@ -30,9 +30,9 @@ requirements:
     - numpy
     - python x.x
     run:
-    - stsci-hst
-    - stsci-data-analysis
-    - astropy >=1.1
+    - stsci-hst >=3.0.0
+    - stsci-data-analysis >=2.0.2
+    - astropy >=1.3
     - cfitsio >=3.370
     - d2to1 >=0.2.12
     - ds9 >=7.1

--- a/stwcs/meta.yaml
+++ b/stwcs/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'stwcs' %}
-{% set version = '1.2.5' %}
-{% set number = '1' %}
+{% set version = '1.3.2' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}


### PR DESCRIPTION
- _CRDS rolls back to 7.1.1 from 7.1.3 (rebased out due to build delays. Trust me we built 7.1.1)