### PR TITLE
Hyphenate package name

### DIFF
--- a/spherical-geometry/meta.yaml
+++ b/spherical-geometry/meta.yaml
@@ -1,9 +1,10 @@
-{% set name = 'spherical_geometry' %}
+{% set name = 'spherical-geometry' %}
+{% set reponame = 'spherical_geometry' %}
 {% set version = '1.0.10' %}
 {% set number = '0' %}
 
 about:
-    home: https://github.com/spacetelescope/{{ name }}
+    home: https://github.com/spacetelescope/{{ reponame }}
     license: BSD
     summary: For handling spherical polygons that represent arbitrary regions of the sky
 
@@ -29,7 +30,7 @@ requirements:
 
 source:
     git_tag: {{ version }}
-    git_url: https://github.com/spacetelescope/{{ name }}.git
+    git_url: https://github.com/spacetelescope/{{ reponame }}.git
 
 test:
     imports:


### PR DESCRIPTION
Match package name with existing PyPI package spherical-geometry. Decouple package name from repository name to accommodate previous naming decisions. (See https://github.com/spacetelescope/spherical_geometry/issues/104)