### PR TITLE
Bump ACSTOOLS to 2.0.9

### DIFF
--- a/acstools/meta.yaml
+++ b/acstools/meta.yaml
@@ -1,11 +1,11 @@
 {% set name = 'acstools' %}
-{% set version = '2.0.8' %}
+{% set version = '2.0.9' %}
 {% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}
     license: BSD
-    summary: For analyzing ACS data
+    summary: Python tools for analyzing ACS data
 build:
     number: {{ number }}
 package:


### PR DESCRIPTION
HSTDP does not use anything here (yet), so theoretically this can be merged anytime. I would like this to be merged as soon as possible, because `satdet` on AstroConda will not run properly with Astropy 2.0 until this is in.

c/c @dborncamp