### PR TITLE
Update jwst_coronagraph_visibility to 0.3.0

### DIFF
--- a/jwst_coronagraph_visibility/meta.yaml
+++ b/jwst_coronagraph_visibility/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'jwst_coronagraph_visibility' %}
-{% set version = '0.2.0' %}
+{% set version = '0.3.0' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Fixing two issues with the GUI:

https://github.com/spacetelescope/jwst_coronagraph_visibility/issues/15 - NIRCam A long-wavelength bar mask is flipped left-to-right in GUI

https://github.com/spacetelescope/jwst_coronagraph_visibility/issues/12 - Clear SIMBAD search field when user enters RA/Dec or chooses an example

