### PR TITLE
Bump spherical-geometry to 1.0.11

### DIFF
--- a/spherical-geometry/meta.yaml
+++ b/spherical-geometry/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'spherical-geometry' %}
 {% set reponame = 'spherical_geometry' %}
-{% set version = '1.0.10' %}
+{% set version = '1.0.11' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
To be consistent with PyPi. See spacetelescope/spherical_geometry#102

c/c @bernie-simon 