### PR TITLE
Updated glue recipes to latest versions

### DIFF
--- a/glue-core/meta.yaml
+++ b/glue-core/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'glue-core' %}
-{% set version = '0.10.1' %}
+{% set version = '0.11.0' %}
 {% set number = '0' %}
 
 package:
@@ -9,7 +9,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/g/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: bf0d8d2c2fba069d554aadb9acce5292
+  md5: 662aef48eb6bf4005aa433cea905c0a6
 
 build:
   number: {{ number }}

--- a/glue-core/meta.yaml
+++ b/glue-core/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'glue-core' %}
-{% set version = '0.11.0' %}
+{% set version = '0.11.1' %}
 {% set number = '0' %}
 
 package:
@@ -9,7 +9,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/g/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: 662aef48eb6bf4005aa433cea905c0a6
+  sha256: 9a1085ec093e35cc724da4ebff0092558489e089dd128d222ff81c9115f91bb1
 
 build:
   number: {{ number }}

--- a/glue-vispy-viewers/bld.bat
+++ b/glue-vispy-viewers/bld.bat
@@ -1,1 +1,0 @@
-%PYTHON% setup.py install

--- a/glue-vispy-viewers/build.sh
+++ b/glue-vispy-viewers/build.sh
@@ -1,1 +1,0 @@
-$PYTHON setup.py install

--- a/glue-vispy-viewers/meta.yaml
+++ b/glue-vispy-viewers/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'glue-vispy-viewers' %}
-{% set version = "0.7.2" %}
+{% set version = "0.8" %}
 {% set number = '0' %}
 
 package:
@@ -9,10 +9,11 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/g/glue-vispy-viewers/{{ name }}-{{ version }}.tar.gz
-  md5: 58cd60967ed1b80b965b0627b2d3bd77
+  md5: 86134446dc50b5060f0ae8563e0fe677
 
 build:
   number: {{ number }}
+  script: python setup.py install --single-version-externally-managed --record record.txt
   preserve_egg_dir: True
 
 requirements:
@@ -21,13 +22,13 @@ requirements:
     - setuptools
     - numpy
     - pyopengl
-    - glue-core >=0.10
+    - glue-core >=0.11
 
   run:
     - python
     - numpy
     - pyopengl
-    - glue-core >=0.10
+    - glue-core >=0.11
     - matplotlib
     - qtpy
     - pyqt

--- a/glueviz/meta.yaml
+++ b/glueviz/meta.yaml
@@ -3,7 +3,7 @@
 # app: entry here and not in the glue-core package.
 
 {% set name = 'glueviz' %}
-{% set version = '0.11.0' %}
+{% set version = '0.11.1' %}
 {% set number = '0' %}
 
 package:
@@ -13,7 +13,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/g/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: 03954cd633bd7be25472d529034cb8fb
+  sha256: 3d5c3ea90d78d3186ff60ff8094e3c0b09c6e040d94210d29a8370a60aa134d5
 
 build:
   number: {{ number }}
@@ -23,12 +23,12 @@ requirements:
   build:
     - python
     - setuptools
-    - glue-core >=0.11.0
+    - glue-core >=0.11.1
     - glue-vispy-viewers >=0.8
     - glue-ginga
 
   run:
-    - glue-core >=0.11.0
+    - glue-core >=0.11.1
     - glue-vispy-viewers >=0.8
     - glue-ginga
 

--- a/glueviz/meta.yaml
+++ b/glueviz/meta.yaml
@@ -3,24 +3,33 @@
 # app: entry here and not in the glue-core package.
 
 {% set name = 'glueviz' %}
-{% set version = '0.10.1' %}
+{% set version = '0.11.0' %}
 {% set number = '0' %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/g/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  md5: 03954cd633bd7be25472d529034cb8fb
+
 build:
   number: {{ number }}
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
     - setuptools
-    - glue-vispy-viewers >=0.7.2
+    - glue-core >=0.11.0
+    - glue-vispy-viewers >=0.8
+    - glue-ginga
 
   run:
-    - glue-vispy-viewers >=0.7.2
+    - glue-core >=0.11.0
+    - glue-vispy-viewers >=0.8
     - glue-ginga
 
 app:


### PR DESCRIPTION
Replaces https://github.com/astroconda/astroconda-contrib/pull/220

These should be built in the following order: glue-core, glue-vispy-viewers, then glueviz