### PR TITLE
Make release 2.1.18

### DIFF
--- a/drizzlepac/meta.yaml
+++ b/drizzlepac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'drizzlepac' %}
-{% set version = '2.1.17' %}
+{% set version = '2.1.18' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Bug fixes and improvements included in 2.1.18:

https://github.com/spacetelescope/drizzlepac/pull/75 https://github.com/spacetelescope/drizzlepac/pull/80 and https://github.com/spacetelescope/drizzlepac/pull/82
