### PR TITLE
Fix circular dependency; recipe standardization

### DIFF
--- a/glue-ginga/meta.yaml
+++ b/glue-ginga/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'glue-ginga' %}
 {% set version = '0.1.1' %}
 {% set tag = 'v' + version %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/ejeschke/{{ name }}
@@ -18,7 +18,8 @@ package:
 requirements:
     build:
     - astropy >=1.2
-    - glueviz >=0.10
+    - glue-core >=0.11.1
+    - glue-vispy-viewers >=0.8
     - ginga >=2.6.1
     - setuptools
     - numpy

--- a/glueviz/meta.yaml
+++ b/glueviz/meta.yaml
@@ -4,7 +4,7 @@
 
 {% set name = 'glueviz' %}
 {% set version = '0.11.1' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 package:
   name: {{ name }}
@@ -20,13 +20,6 @@ build:
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
-  build:
-    - python
-    - setuptools
-    - glue-core >=0.11.1
-    - glue-vispy-viewers >=0.8
-    - glue-ginga
-
   run:
     - glue-core >=0.11.1
     - glue-vispy-viewers >=0.8


### PR DESCRIPTION
* Fix circular dependency
* Remove metapackage build requirements 
   * Investigation into behavior of conda-build 2.x vs conda-build 3.x indicates that using metapackages in recipe requirements may cause problems. Existing tool behavior and documentation suggests that this may not be a supported configuration.
* Increment build numbers