### PR TITLE
Release drizzlepac v2.1.20

### DIFF
--- a/drizzlepac/meta.yaml
+++ b/drizzlepac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'drizzlepac' %}
-{% set version = '2.1.19' %}
+{% set version = '2.1.20' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Fixed catalog doubling and catalog filtering issues in tweakreg. See https://github.com/spacetelescope/drizzlepac/pull/90 for more details.

CC: @rendinam 