### PR TITLE
Release stsci.skypac v0.9.6

### DIFF
--- a/stsci.skypac/meta.yaml
+++ b/stsci.skypac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.skypac' %}
-{% set version = '0.9.5' %}
+{% set version = '0.9.6' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
This release fixes a file open mode for temporary mask files to make code compatible with latest changes in astropy: see https://github.com/spacetelescope/stsci.skypac/pull/15 and https://github.com/spacetelescope/drizzlepac/issues/84 for more details.

CC: @rendinam @stsci-hack 