### PR TITLE
Bug fixes release v0.9.7

### DIFF
--- a/stsci.skypac/meta.yaml
+++ b/stsci.skypac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.skypac' %}
-{% set version = '0.9.6' %}
+{% set version = '0.9.7' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
See https://github.com/spacetelescope/stsci.skypac/pull/19 for details. Fundamentally, version removal in v0.9.6 broke `skypac`.