### PR TITLE
asdf: Dropped "v" prefix upstream

### DIFF
--- a/asdf/meta.yaml
+++ b/asdf/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = 'asdf' %}
 {% set version = '1.3.1' %}
-{% set tag = 'v' + version %}
-{% set number = '1' %}
+{% set number = '2' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}
@@ -38,7 +37,7 @@ requirements:
     - python x.x
 
 source:
-    git_tag: {{ tag }}
+    git_tag: {{ version }}
     git_url: https://github.com/spacetelescope/{{ name }}.git
 
 test:


### PR DESCRIPTION
@rendinam In conda-dev, the resolver found `1.2.1` rather than `v1.3.1` as the latest version.  @drdavella has re-tagged the repository and dropped the "v" prefix.