### PR TITLE
stsci-hst: lock stwcs version range under py27

### DIFF
--- a/stsci-hst/meta.yaml
+++ b/stsci-hst/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'stsci-hst' %}
-{% set version = '3.0.0' %}
-{% set number = '1' %}
+{% set version = '3.0.1' %}
+{% set number = '0' %}
 
 about:
     home: http://ssb.stsci.edu
@@ -15,39 +15,6 @@ package:
     version: {{ version }}
 
 requirements:
-    build:
-    - purge_path >=1.0.0
-    - acstools >=2.0.8
-    - astropy >=1.3
-    - calcos >=3.2.1
-    - costools >=1.2.1
-    - crds >=7.1.1
-    - d2to1 >=0.2.12
-    - drizzlepac >=2.1.17
-    - fitsblender >=0.3.2
-    - hstcal >=1.2.0
-    - nictools >=1.1.3
-    - pyregion >=1.1.2
-    - pysynphot >=0.9.8.7
-    - reftools >=1.7.4
-    - stistools >=1.1
-    - stsci.convolve >=2.2.1
-    - stsci.distutils >=0.3.8
-    - stsci.image >=2.2.0
-    - stsci.imagemanip >=1.1.2
-    - stsci.imagestats >=1.4.1
-    - stsci.ndimage >=0.10.1
-    - stsci.numdisplay >=1.6.1
-    - stsci.sphinxext >=1.2.2
-    - stsci.stimage >=0.2.1
-    - stsci.skypac >=0.9.5
-    - stsci.sphere >=0.2
-    - stsci.tools >=3.4.11
-    - stwcs >=1.3.2
-    - wfpc2tools >=1.0.3
-    - wfc3tools >=1.3.4
-    - numpy
-    - python x.x
     run:
     - purge_path >=1.0.0
     - acstools >=2.0.8
@@ -76,8 +43,9 @@ requirements:
     - stsci.skypac >=0.9.5
     - stsci.sphere >=0.2
     - stsci.tools >=3.4.11
-    - stwcs >=1.3.2
+    - stwcs >=1.3.2,<1.4.0 [py27]
+    - stwcs >=1.3.2 [not py27]
     - wfpc2tools >=1.0.3
     - wfc3tools >=1.3.4
     - numpy
-    - python x.x
+    - python


### PR DESCRIPTION
BUGFIX: Prevent incompatible package, stwcs-1.4.0, from entering the py27 environment