### PR TITLE
Avoid python-agnostic packages

### DIFF
--- a/stsci-data-analysis/meta.yaml
+++ b/stsci-data-analysis/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = 'stsci-data-analysis' %}
-{% set version = '2.1.0' %}
+{% set version = '2.1.1' %}
 {% if version[0] == 'v' %}
 {%   set version = version[1:] %}
 {% endif %}
-{% set number = '1' %}
+{% set number = '0' %}
 
 about:
     home: http://ssb.stsci.edu
@@ -18,21 +18,25 @@ package:
     version: {{ version }}
 
 requirements:
+    build:
+      - numpy {{ numpy }}
+      - python {{ python }}
+
     run:
-    - asdf >=1.3.1
-    - astropy >=2.0.0
-    - astroimtools >=0.1.1
-    - cubeviz >=0.0.2
-    - glueviz >=0.12.0
-    - glue-ginga >=0.2
-    - glue-vispy-viewers >=0.9
-    - gwcs >=0.8.0
-    - mosviz >=0.1.1
-    - photutils >=0.4
-    - imexam >=0.8.0
-    - specutils >=0.2.2
-    - specviz >=0.4.4
-    - spherical-geometry >=1.0.12
-    - stginga >=0.2.1
-    - numpy
-    - python
+      - asdf >=1.3.1
+      - astropy >=2.0.0
+      - astroimtools >=0.1.1
+      - cubeviz >=0.0.2
+      - glueviz >=0.12.0
+      - glue-ginga >=0.2
+      - glue-vispy-viewers >=0.9
+      - gwcs >=0.8.0
+      - mosviz >=0.1.1
+      - photutils >=0.4
+      - imexam >=0.8.0
+      - specutils >=0.2.2
+      - specviz >=0.4.4
+      - spherical-geometry >=1.0.12
+      - stginga >=0.2.1
+      - numpy
+      - python

--- a/stsci-hst/meta.yaml
+++ b/stsci-hst/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = 'stsci-hst' %}
-{% set version = '3.0.1' %}
+{% set version = '3.0.2' %}
 {% if version[0] == 'v' %}
 {%   set version = version[1:] %}
 {% endif %}
-{% set number = '1' %}
+{% set number = '0' %}
 
 about:
     home: http://ssb.stsci.edu
@@ -18,36 +18,41 @@ package:
     version: {{ version }}
 
 requirements:
+    build:
+      - numpy {{ numpy }}
+      - python {{ python }}
+
     run:
-    - acstools >=2.0.8
-    - astropy >=1.3
-    - calcos >=3.2.1
-    - costools >=1.2.1
-    - crds >=7.1.1
-    - d2to1 >=0.2.12
-    - drizzlepac >=2.1.17
-    - fitsblender >=0.3.2
-    - hstcal >=1.2.0
-    - nictools >=1.1.3
-    - pyregion >=1.1.2
-    - pysynphot >=0.9.8.7
-    - reftools >=1.7.4
-    - stistools >=1.1
-    - stsci.convolve >=2.2.1
-    - stsci.distutils >=0.3.8
-    - stsci.image >=2.2.0
-    - stsci.imagemanip >=1.1.2
-    - stsci.imagestats >=1.4.1
-    - stsci.ndimage >=0.10.1
-    - stsci.numdisplay >=1.6.1
-    - stsci.sphinxext >=1.2.2
-    - stsci.stimage >=0.2.1
-    - stsci.skypac >=0.9.5
-    - stsci.sphere >=0.2
-    - stsci.tools >=3.4.11
-    - stwcs >=1.3.2,<1.4.0 [py27]
-    - stwcs >=1.3.2 [not py27]
-    - wfpc2tools >=1.0.3
-    - wfc3tools >=1.3.4
-    - numpy
-    - python
+      - purge_path >=1.0.0
+      - acstools >=2.0.8
+      - astropy >=1.3
+      - calcos >=3.2.1
+      - costools >=1.2.1
+      - crds >=7.1.1
+      - d2to1 >=0.2.12
+      - drizzlepac >=2.1.17
+      - fitsblender >=0.3.2
+      - hstcal >=1.2.0
+      - nictools >=1.1.3
+      - pyregion >=1.1.2
+      - pysynphot >=0.9.8.7
+      - reftools >=1.7.4
+      - stistools >=1.1
+      - stsci.convolve >=2.2.1
+      - stsci.distutils >=0.3.8
+      - stsci.image >=2.2.0
+      - stsci.imagemanip >=1.1.2
+      - stsci.imagestats >=1.4.1
+      - stsci.ndimage >=0.10.1
+      - stsci.numdisplay >=1.6.1
+      - stsci.sphinxext >=1.2.2
+      - stsci.stimage >=0.2.1
+      - stsci.skypac >=0.9.5
+      - stsci.sphere >=0.2
+      - stsci.tools >=3.4.11
+      - stwcs >=1.3.2,<1.4.0 [py27]
+      - stwcs >=1.3.2 [not py27]
+      - wfpc2tools >=1.0.3
+      - wfc3tools >=1.3.4
+      - numpy
+      - python

--- a/stsci/meta.yaml
+++ b/stsci/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = 'stsci' %}
-{% set version = '3.0.0' %}
+{% set version = '3.0.2' %}
 {% if version[0] == 'v' %}
 {%   set version = version[1:] %}
 {% endif %}
-{% set number = '1' %}
+{% set number = '0' %}
 
 about:
     home: http://ssb.stsci.edu
@@ -18,15 +18,21 @@ package:
     version: {{ version }}
 
 requirements:
-    - stsci-hst >=3.0.0
-    - stsci-data-analysis >=2.0.2
-    - astropy >=1.3
-    - cfitsio >=3.370
-    - d2to1 >=0.2.12
-    - ds9 >=7.1
-    - fftw >=3.3.4
-    - htc_utils >=0.1
-    - pyds9 >=1.8.1
-    - pyfftw >=0.9.2
-    - numpy
-    - python
+    build:
+      - numpy {{ numpy }}
+      - python {{ python }}
+
+    run:
+      - stsci-hst >=3.0.0
+      - stsci-data-analysis >=2.0.2
+      - astropy >=1.3
+      - cfitsio >=3.370
+      - d2to1 >=0.2.12
+      - ds9 >=7.1
+      - fftw >=3.3.4
+      - htc_utils >=0.1
+      - purge_path >=1.0.0
+      - pyds9 >=1.8.1
+      - pyfftw >=0.9.2
+      - numpy
+      - python


### PR DESCRIPTION
If runtime logic appears in a recipe specific to a certain version (or versions) of python, the Conda's selector logic will only be applied ONE TIME, using whichever version of python is active in the build environment.

Unacceptable.

