### PR TITLE
Make stsci.image release 2.3.0 with updated numcombine

### DIFF
--- a/stsci.image/meta.yaml
+++ b/stsci.image/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.image' %}
-{% set version = '2.2.0' %}
+{% set version = '2.3.0' %}
 {% set number = '2' %}
 
 about:


### PR DESCRIPTION
The code in numcombine has been updated in https://github.com/spacetelescope/stsci.image/pull/4 Making a new release.

CC: @rendinam @jhunkeler 