### PR TITLE
Cfitsio: curl

### DIFF
--- a/cfitsio/build.sh
+++ b/cfitsio/build.sh
@@ -1,3 +1,8 @@
+case "$(uname)" in
+    Darwin)
+        export CFLAGS="$CFLAGS -D_POSIX_C_SOURCE=200112L"
+        ;;
+esac
 ./configure --prefix=$PREFIX --disable-static --enable-reentrant
 make -j $CPU_COUNT shared
 make install

--- a/cfitsio/build.sh
+++ b/cfitsio/build.sh
@@ -1,3 +1,3 @@
-
 ./configure --prefix=$PREFIX --disable-static --enable-reentrant
-(make -j $CPU_COUNT shared && make install)
+make -j $CPU_COUNT shared
+make install

--- a/cfitsio/meta.yaml
+++ b/cfitsio/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'cfitsio' %}
 {% set version = '3.430' %}
 {% set version_short = '3430' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: http://heasarc.gsfc.nasa.gov/fitsio/fitsio.html
@@ -16,6 +16,13 @@ build:
 package:
     name: {{ name }}
     version: {{ version }}
+
+requirements:
+    build:
+      - curl
+
+    run:
+      - curl
 
 source:
     fn: {{ name }}{{ version_short }}.tar.gz

--- a/cfitsio/meta.yaml
+++ b/cfitsio/meta.yaml
@@ -20,9 +20,11 @@ package:
 requirements:
     build:
       - curl
+      - gcc [osx]
 
     run:
       - curl
+      - libgcc [osx]
 
 source:
     fn: {{ name }}{{ version_short }}.tar.gz


### PR DESCRIPTION
Allowing `libcfitsio` to link against the system's `libcurl` has undesired results on different OSes. Linking against Conda's `curl` should help, but I can't promise Continuum will not break it at some point.

**Note:** The recipe has been aligned with its -dev counterpart.