### PR TITLE
Bump PySynphot to 0.9.10

### DIFF
--- a/pysynphot/meta.yaml
+++ b/pysynphot/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'pysynphot' %}
-{% set version = '0.9.9' %}
+{% set version = '0.9.10' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Released today. Fresh and hot!