### PR TITLE
Cubeviz 0.2.0 release

### DIFF
--- a/cubeviz/meta.yaml
+++ b/cubeviz/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'cubeviz' %}
 {% set version = '0.2.0' %}
-{% set tag = 'v' + version %}
+{% set tag = version %}
 {% set number = '1' %}
 
 about:

--- a/cubeviz/meta.yaml
+++ b/cubeviz/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'cubeviz' %}
-{% set version = '0.0.2' %}
+{% set version = '0.2.0' %}
 {% set number = '1' %}
 
 about:
@@ -19,7 +19,7 @@ requirements:
     - asdf
     - asteval
     - astropy
-    - glue-core >=0.12.0
+    - glue-core =0.13
     - numpy {{ numpy }}
     - pytest
     - setuptools
@@ -29,7 +29,7 @@ requirements:
     - asdf
     - asteval
     - astropy
-    - glue-core >=0.12.0
+    - glue-core =0.13
     - numpy
     - pytest
     - python

--- a/cubeviz/meta.yaml
+++ b/cubeviz/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'cubeviz' %}
 {% set version = '0.2.0' %}
 {% set tag = version %}
-{% set number = '1' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}

--- a/cubeviz/meta.yaml
+++ b/cubeviz/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - asdf
     - asteval
     - astropy
-    - glue-core =0.13
+    - glue-core >=0.13
     - numpy {{ numpy }}
     - pytest
     - setuptools
@@ -30,7 +30,7 @@ requirements:
     - asdf
     - asteval
     - astropy
-    - glue-core =0.13
+    - glue-core >=0.13
     - numpy
     - pytest
     - python

--- a/cubeviz/meta.yaml
+++ b/cubeviz/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = 'cubeviz' %}
 {% set version = '0.2.0' %}
+{% set tag = 'v' + version %}
 {% set number = '1' %}
 
 about:

--- a/specviz/meta.yaml
+++ b/specviz/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'specviz' %}
-{% set version = '0.4.4' %}
+{% set version = '0.5.0' %}
 {% set tag = 'v' + version %}
 {% set number = '1' %}
 

--- a/specviz/meta.yaml
+++ b/specviz/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'specviz' %}
 {% set version = '0.5.0' %}
 {% set tag = 'v' + version %}
-{% set number = '1' %}
+{% set number = '0' %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
These are (hopefully) the changes for the Cubeviz 0.2.0 release.  This release is dependent on:
* glue v0.13
* specviz 0.5
* specutils 'legacy-specutils'
* spectral-cube

Tom created is v0.13 release for Glue several hours ago and uploaded to his glue conda channel.  Nick created his 0.5 specviz release on Wednesday.

