### PR TITLE
add pysiaf recipe

### DIFF
--- a/pysiaf/bld.bat
+++ b/pysiaf/bld.bat
@@ -1,0 +1,2 @@
+
+%PYTHON% setup.py install

--- a/pysiaf/build.sh
+++ b/pysiaf/build.sh
@@ -1,0 +1,2 @@
+
+$PYTHON setup.py install

--- a/pysiaf/meta.yaml
+++ b/pysiaf/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - openpyxl >=2.4
     - python {{ python }}
     - setuptools
-    - python-dateutil
+    
     run:
     - astropy >=1.2
     - numpy >=1.9
@@ -39,4 +39,4 @@ requirements:
 
 test:
     imports:
-        pysiaf
+      - pysiaf

--- a/pysiaf/meta.yaml
+++ b/pysiaf/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = 'pysiaf' %}
+{% set version = '0.1.8' %}
+{% set tag = version %}
+{% set number = '0' %}
+
+about:
+    home: https://github.com/spacetelescope/{{ name }}
+    license: BSD
+    summary: 
+        Handling of Science Instrument Aperture Files (SIAF) for space telescopes
+
+source:
+    git_tag: {{ tag }}
+    git_url: https://github.com/spacetelescope/{{ name }}.git
+
+package:
+    name: {{ name }}
+    version: {{ version }}
+
+requirements:
+    build:
+    - astropy >=1.2
+    - numpy >=1.9
+    - matplotlib >=1.4.3
+    - lxml >=3.6.4
+    - scipy >=0.17
+    - openpyxl >=2.4
+    - python {{ python }}
+    - setuptools
+    - python-dateutil
+    run:
+    - astropy >=1.2
+    - numpy >=1.9
+    - matplotlib >=1.4.3
+    - lxml >=3.6.4
+    - scipy >=0.17
+    - openpyxl >=2.4
+    - python {{ python }}
+
+test:
+    imports:
+        pysiaf


### PR DESCRIPTION
pysiaf (https://github.com/spacetelescope/pysiaf ) implements Science Instrument Aperture File handling for space telescopes, in particular HST and JWST. It's on PyPI already but needs to be added to astroconda, which this PR does. 