### PR TITLE
pysiaf: Add missing build number field

### DIFF
--- a/pysiaf/meta.yaml
+++ b/pysiaf/meta.yaml
@@ -17,6 +17,9 @@ package:
     name: {{ name }}
     version: {{ version }}
 
+build:
+    number: {{ number }}
+    
 requirements:
     build:
     - astropy >=1.2


### PR DESCRIPTION
Rambo fails with this otherwise:

```python
Traceback (most recent call last):
  File "/Users/iraf/build/banana/workspace/AstroConda/public_OSX-10.11_py3.5_np1.11/_dispatch/miniconda/bin/rambo", line 11, in <module>
    load_entry_point('rambo==1.0.0b5', 'console_scripts', 'rambo')()
  File "/Users/iraf/build/banana/workspace/AstroConda/public_OSX-10.11_py3.5_np1.11/_dispatch/miniconda/lib/python3.5/site-packages/rambo-1.0.0b5-py3.5.egg/rambo/__main__.py", line 136, in main
  File "/Users/iraf/build/banana/workspace/AstroConda/public_OSX-10.11_py3.5_np1.11/_dispatch/miniconda/lib/python3.5/site-packages/rambo-1.0.0b5-py3.5.egg/rambo/meta.py", line 197, in __init__
  File "/Users/iraf/build/banana/workspace/AstroConda/public_OSX-10.11_py3.5_np1.11/_dispatch/miniconda/lib/python3.5/site-packages/rambo-1.0.0b5-py3.5.egg/rambo/meta.py", line 367, in read_recipes
  File "/Users/iraf/build/banana/workspace/AstroConda/public_OSX-10.11_py3.5_np1.11/_dispatch/miniconda/lib/python3.5/site-packages/rambo-1.0.0b5-py3.5.egg/rambo/meta.py", line 336, in read_recipe_selection
KeyError: 'build'
```

https://github.com/astroconda/rambo/blob/aad73bb6d561713c1855e9b3731e2e8f39cfd1f5/rambo/meta.py#L332-L336