### PR TITLE
Added optional parameters to PAM utilities in stsci.skypac

### DIFF
--- a/stsci.skypac/meta.yaml
+++ b/stsci.skypac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.skypac' %}
-{% set version = '0.9.12' %}
+{% set version = '0.9.14' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
See https://github.com/spacetelescope/stsci.skypac/pull/36 for more details.

Skipped v0.9.13 due to an incorrectly (prematurely) applied tag.

CC: @rendinam @jhunkeler 