### PR TITLE
Bump Ginga to 2.7.1

### DIFF
--- a/ginga/meta.yaml
+++ b/ginga/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'ginga' %}
-{% set version = '2.7.0' %}
+{% set version = '2.7.1' %}
 {% set tag = 'v' ~ version %}
 {% set number = '0' %}
 


### PR DESCRIPTION
Fresh off the oven for Scipy 2018.

https://github.com/ejeschke/ginga/releases/tag/v2.7.1