### PR TITLE
astropy-healpix: drop setuptools constraint

### DIFF
--- a/astropy-healpix/meta.yaml
+++ b/astropy-healpix/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   build:
     - astropy
     - cython
-    - setuptools <38.5.1
+    - setuptools
     - numpy {{ numpy }}
     - python {{ python }}
 


### PR DESCRIPTION
This was previously accounting for an older broken release of setuptools.