### PR TITLE
stsci.imagemanip: Update 1.1.2 -> 1.1.4

### DIFF
--- a/stsci.imagemanip/meta.yaml
+++ b/stsci.imagemanip/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'stsci.imagemanip' %}
-{% set version = '1.1.2' %}
-{% set number = '2' %}
+{% set version = '1.1.4' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}


### PR DESCRIPTION
Fixes `stsci.tools.tester` incompatibility

https://github.com/spacetelescope/stsci.imagemanip/issues/9
https://github.com/spacetelescope/stsci.imagemanip/pull/10