### PR TITLE
Deprecate pyregion

### DIFF
--- a/pyregion/meta.yaml
+++ b/pyregion/meta.yaml
@@ -9,6 +9,7 @@ about:
 
 build:
     number: {{ number }}
+    skip: True
 
 package:
     name: {{ name }}

--- a/stsci-hst/meta.yaml
+++ b/stsci-hst/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci-hst' %}
-{% set version = '3.0.2' %}
+{% set version = '3.0.3' %}
 {% set number = '0' %}
 
 about:
@@ -31,7 +31,6 @@ requirements:
       - fitsblender >=0.3.2
       - hstcal >=1.2.0
       - nictools >=1.1.3
-      - pyregion >=1.1.2
       - pysynphot >=0.9.8.7
       - reftools >=1.7.4
       - stistools >=1.1


### PR DESCRIPTION
Replaced by `stregion`

Note: There's no reason to list `stregion` as a global dependency seeing as `drizzlepac` is the only package that depends on it.