### PR TITLE
Bump ci-watson to 0.1.2

### DIFF
--- a/ci-watson/meta.yaml
+++ b/ci-watson/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'ci-watson' %}
 {% set reponame = 'ci_watson' %}
-{% set version = '0.1.1' %}
+{% set version = '0.1.2' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
To get rid of deprecation warnings.