### PR TITLE
Add deps needed for use on default linux build machine.

### DIFF
--- a/ds9/meta.yaml
+++ b/ds9/meta.yaml
@@ -18,6 +18,8 @@ package:
 requirements:
     build:
     - gcc >=4.6 [osx]
+    - autoconf
+    - m4
 
 source:
     fn: {{ name }}.{{ version }}.tar.gz


### PR DESCRIPTION
Build failed with old version errors on autotools components available on the usual linux build machine. This provides newer ones that let the build proceed.