### PR TITLE
Updated version to 7.2.8

### DIFF
--- a/crds/meta.yaml
+++ b/crds/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'crds' %}
-{% set version = '7.2.7' %}
+{% set version = '7.2.8' %}
 {% set number = '0' %}
 
 about:

--- a/crds/meta.yaml
+++ b/crds/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'crds' %}
-{% set version = '7.2.6' %}
+{% set version = '7.2.7' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
CRDS-7.2.6 was tagged incorrectly so it's missing some key changes.  

Among other things this adds support for JWST REFTYPE=PSFMASK.