### PR TITLE
Bump ci-watson to 0.2

### DIFF
--- a/ci-watson/meta.yaml
+++ b/ci-watson/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'ci-watson' %}
 {% set reponame = 'ci_watson' %}
-{% set version = '0.1.2' %}
+{% set version = '0.2' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Spooktacular release!

cc @jdavies-st -- `ci-watson` is in our `conda` channel here, so not sure what you mean by it is not available on `conda` for `jwst`.