### PR TITLE
Make release 2.2.6 of drizzlepac

### DIFF
--- a/drizzlepac/meta.yaml
+++ b/drizzlepac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'drizzlepac' %}
-{% set version = '2.2.4' %}
+{% set version = '2.2.6' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
It looks like release 2.2.5 was actually never released... So this release includes all the changes from `2.2.5` and `2.2.6` as described in the changelog, most important being fixing the units of output CR-cleaned (`'*_crclean.fits'`) images optionally produced by `drizzlepac` - see https://github.com/spacetelescope/drizzlepac/pull/190

CC: @rendinam 