### PR TITLE
Bump Ginga to 2.7.2

### DIFF
--- a/ginga/meta.yaml
+++ b/ginga/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'ginga' %}
-{% set version = '2.7.1' %}
+{% set version = '2.7.2' %}
 {% set tag = 'v' ~ version %}
 {% set number = '0' %}
 


### PR DESCRIPTION
For ADASS 2018 next week.

https://github.com/ejeschke/ginga/releases/tag/v2.7.2