### PR TITLE
Update to reflect ASDF v2.2.1 release

### DIFF
--- a/asdf/meta.yaml
+++ b/asdf/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'asdf' %}
-{% set version = '2.1.1' %}
+{% set version = '2.2.1' %}
 {% set number = '1' %}
 
 about:


### PR DESCRIPTION
Skipping the 2.2.0 release since there was a bug.

@rendinam I'm not sure how this works. It seems like #422 will need to be merged first, and then this one?