### PR TITLE
Fix py37 package resolution failures

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,9 +1,10 @@
 python:
   - 3.5
   - 3.6
+  - 3.7
 
 numpy:
-  - 1.12
+  - 1.14
 
 pin_build_as_run:
   python:

--- a/stsci-data-analysis/meta.yaml
+++ b/stsci-data-analysis/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci-data-analysis' %}
-{% set version = '2.1.1' %}
+{% set version = '2.2.0' %}
 {% set number = '0' %}
 
 about:
@@ -25,7 +25,6 @@ requirements:
       - astroimtools >=0.1.1
       - cubeviz >=0.0.2
       - glueviz >=0.12.0
-      - glue-ginga >=0.2
       - glue-vispy-viewers >=0.9
       - gwcs >=0.8.0
       - mosviz >=0.1.1

--- a/stsci-hst/meta.yaml
+++ b/stsci-hst/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci-hst' %}
-{% set version = '3.0.3' %}
+{% set version = '3.1.0' %}
 {% set number = '0' %}
 
 about:
@@ -20,9 +20,8 @@ requirements:
       - python {{ python }}
 
     run:
-      - purge_path >=1.0.0
       - acstools >=2.0.8
-      - astropy >=1.3
+      - astropy >=2.0.0
       - calcos >=3.2.1
       - costools >=1.2.1
       - crds >=7.1.1
@@ -40,11 +39,9 @@ requirements:
       - stsci.imagemanip >=1.1.2
       - stsci.imagestats >=1.4.1
       - stsci.ndimage >=0.10.1
-      - stsci.numdisplay >=1.6.1
       - stsci.sphinxext >=1.2.2
       - stsci.stimage >=0.2.1
       - stsci.skypac >=0.9.5
-      - stsci.sphere >=0.2
       - stsci.tools >=3.4.11
       - stwcs >=1.3.2,<1.4.0 [py27]
       - stwcs >=1.3.2 [not py27]

--- a/stsci/meta.yaml
+++ b/stsci/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'stsci' %}
-{% set version = '3.0.2' %}
-{% set number = '1' %}
+{% set version = '3.1.0' %}
+{% set number = '0' %}
 
 about:
     home: http://ssb.stsci.edu
@@ -20,15 +20,14 @@ requirements:
       - python {{ python }}
 
     run:
-      - stsci-hst >=3.0.0
-      - stsci-data-analysis >=2.0.2
-      - astropy >=1.3
+      - stsci-hst >=3.1.0
+      - stsci-data-analysis >=2.1.1
+      - astropy >=2.0.0
       - cfitsio >=3.370
       - d2to1 >=0.2.12
       - ds9 >=7.1
       - fftw >=3.3.4
       - htc_utils >=0.1
-      - purge_path >=1.0.0
       - pyds9 >=1.8.1
       - pyfftw >=0.9.2
       - numpy


### PR DESCRIPTION
* Remove totally deprecated dependencies
* Future: If recipe no longer exists... remove from metapackage