### PR TITLE
stsci.imagestats: Disable python 2.7

### DIFF
--- a/stsci.imagestats/meta.yaml
+++ b/stsci.imagestats/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'stsci.imagestats' %}
 {% set version = '1.5.3' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}
@@ -11,6 +11,7 @@ about:
 build:
     number: {{ number }}
     preserve_egg_dir: 'yes'
+    skip: True [py2k]
 
 package:
     name: {{ name }}


### PR DESCRIPTION
- Python 3 conventions used during setup.



