### PR TITLE
Update poppy to 0.8.0

### DIFF
--- a/poppy/meta.yaml
+++ b/poppy/meta.yaml
@@ -1,10 +1,10 @@
 {% set name = 'poppy' %}
-{% set version = '0.7.0' %}
+{% set version = '0.8.0' %}
 {% set tag = 'v' + version %}
 {% set number = '0' %}
 
 about:
-    home: https://github.com/mperrin/{{ name }}
+    home: https://github.com/spacetelescope/{{ name }}
     license: BSD
     summary: |
         Physical optics propagation (wavefront diffraction) for optical
@@ -23,20 +23,16 @@ requirements:
     - numpy {{ numpy }}
     - scipy >=0.14.0
     - matplotlib >=1.3.0
-    - six
-    - enum34 [py27]
     - setuptools
-    - python {{ python }}
+    - python >= 3.5
     run:
     - astropy >=1.1
     - numpy
     - scipy >=0.14.0
     - matplotlib >=1.3.0
-    - six
-    - enum34 [py27]
     - setuptools
-    - python
+    - python >= 3.5
 
 source:
     git_tag: {{ tag }}
-    git_url: https://github.com/mperrin/{{ name }}.git
+    git_url: https://github.com/spacetelescope/{{ name }}.git

--- a/poppy/meta.yaml
+++ b/poppy/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - scipy >=0.14.0
     - matplotlib >=1.3.0
     - setuptools
-    - python {{ python }}
+    - python
 
 source:
     git_tag: {{ tag }}

--- a/poppy/meta.yaml
+++ b/poppy/meta.yaml
@@ -12,6 +12,7 @@ about:
 
 build:
     number: {{ number }}
+    skip: true # [py27]
 
 package:
     name: {{ name }}
@@ -24,14 +25,14 @@ requirements:
     - scipy >=0.14.0
     - matplotlib >=1.3.0
     - setuptools
-    - python >= 3.5
+    - python {{ python }}
     run:
     - astropy >=1.1
     - numpy
     - scipy >=0.14.0
     - matplotlib >=1.3.0
     - setuptools
-    - python >= 3.5
+    - python {{ python }}
 
 source:
     git_tag: {{ tag }}


### PR DESCRIPTION
Update for new poppy release version 0.8.0. 

Also, is this the right way to specify that poppy now requires Python 3.5 or greater?