### PR TITLE
Update cubeviz to 0.2.1

### DIFF
--- a/cubeviz/meta.yaml
+++ b/cubeviz/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'cubeviz' %}
-{% set version = '0.2.0' %}
+{% set version = '0.2.1' %}
 {% set tag = version %}
 {% set number = '0' %}
 


### PR DESCRIPTION
`cubeviz 0.2.1` was released back on May 23, 2018, but never updated in astroconda.

I think this `cubeviz` version also requires `specviz >= 0.5 < 0.6`.  I'm not sure if `glue-core >=0.13` also needs to be limited to an older release.  @brechmos-stsci please confirm these dependencies.