### PR TITLE
da5_notebooks: Use underscore not hyphen

### DIFF
--- a/da5_notebooks/meta.yaml
+++ b/da5_notebooks/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = 'da5-notebooks' %}
+{% set name = 'da5_notebooks' %}
 {% set version = '1.0' %}
 {% set tag = 'v' + version %}
 {% set number = '0' %}


### PR DESCRIPTION
Build system isn't keen on mismatches between underscores and hyphens

@larrybradley  affects SDN documentation