### PR TITLE
Reinstate hyphen in package/repo name.

### DIFF
--- a/da5_notebooks/meta.yaml
+++ b/da5_notebooks/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = 'da5_notebooks' %}
+{% set name = 'da5-notebooks' %}
 {% set version = '1.0' %}
 {% set tag = 'v' + version %}
 {% set number = '0' %}


### PR DESCRIPTION
Reverts #447 to synchronize repository name with package name. I was able to build and install the package using this recipe locally. Am I missing something obvious?