### PR TITLE
specviz/specutils: Address py37 build issues (one off)

### DIFF
--- a/specutils/bld.bat
+++ b/specutils/bld.bat
@@ -1,1 +1,1 @@
-%PYTHON% setup.py install
+%PYTHON% setup.py install --single-version-externally-managed --record=root.txt

--- a/specutils/build.sh
+++ b/specutils/build.sh
@@ -1,1 +1,1 @@
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=root.txt

--- a/specutils/meta.yaml
+++ b/specutils/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'specutils' %}
 {% set version = '0.2.2' %}
 {% set tag = 'v' + version %}
-{% set number = '2' %}
+{% set number = '3' %}
 
 about:
     home: https://github.com/astropy/specutils

--- a/specviz/bld.bat
+++ b/specviz/bld.bat
@@ -1,1 +1,1 @@
-%PYTHON% setup.py install
+%PYTHON% setup.py install --single-version-externally-managed --record=root.txt

--- a/specviz/build.sh
+++ b/specviz/build.sh
@@ -1,1 +1,1 @@
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=root.txt

--- a/specviz/meta.yaml
+++ b/specviz/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'specviz' %}
-{% set version = '0.4.4' %}
+{% set version = '0.5.0' %}
 {% set tag = 'v' + version %}
-{% set number = '1' %}
+{% set number = '0' %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
#441 requires older versions of packages that were never compiled successfully under 3.7 prior to the recent updates.

NO-MERGE
NO-MERGE
NO-MERGE

(Branch parent: commit e26d13d100c5eb0015b03845b4df6feab689ba3f)
