### PR TITLE
Recipe updates to fix ah_bootstrap and setuptools

### DIFF
--- a/astroscrappy/build.sh
+++ b/astroscrappy/build.sh
@@ -1,1 +1,2 @@
+curl https://raw.githubusercontent.com/astropy/astropy-helpers/master/ah_bootstrap.py > ah_bootstrap.py
 $PYTHON setup.py install --offline --no-git --single-version-externally-managed --record record.txt

--- a/astroscrappy/meta.yaml
+++ b/astroscrappy/meta.yaml
@@ -20,7 +20,7 @@ package:
 requirements:
   build:
     - astropy
-    - setuptools <38.5.1
+    - setuptools
     - cython
     - numpy {{ numpy }}
     - python {{ python }}

--- a/ccdproc/build.sh
+++ b/ccdproc/build.sh
@@ -1,1 +1,2 @@
+curl https://raw.githubusercontent.com/astropy/astropy-helpers/master/ah_bootstrap.py > ah_bootstrap.py
 $PYTHON setup.py install


### PR DESCRIPTION
Updated recipes to fix python 3.7 conda build failures with the latest setup tools and ah_bootstrap.py