### PR TITLE
webbpsf: Remove jinga2 numpy var from run section

### DIFF
--- a/webbpsf/meta.yaml
+++ b/webbpsf/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'webbpsf' %}
 {% set version = '0.8.0' %}
 {% set tag = 'v' + version %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: https://webbpsf.readthedocs.io
@@ -33,7 +33,7 @@ requirements:
     - pysiaf >=0.1.8
     run:
     - astropy >=1.2
-    - numpy {{numpy}}
+    - numpy
     - scipy >=0.16.0
     - matplotlib >=1.5.0
     - poppy >=0.8.0


### PR DESCRIPTION
Prevents users installing `stsci` from upgrading `numpy` beyond `1.14`
@mcara 