### PR TITLE
Add pin of atomicwrites dependency of pytest to ci-watson

### DIFF
--- a/ci-watson/meta.yaml
+++ b/ci-watson/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     build:
     - pytest
     - setuptools
+    - atomicwrites=1.2.1
     - python {{ python }}
     run:
     - pytest


### PR DESCRIPTION
since ci-watson package will not build against atomicwrites 1.3.0 for some reason.