### PR TITLE
NAXIS12->pixel_shape conversion

### DIFF
--- a/spherical-geometry/meta.yaml
+++ b/spherical-geometry/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'spherical-geometry' %}
 {% set reponame = 'spherical_geometry' %}
-{% set version = '1.2.9' %}
+{% set version = '1.2.10' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Fixed a bug dealing with `NAXIS1,2` deprecation, see https://github.com/spacetelescope/spherical_geometry/pull/165

CC: @jhunkeler 