### PR TITLE
tweakwcs v0.4.6: Improved initial (pre-matching) shift estimate

### DIFF
--- a/tweakwcs/meta.yaml
+++ b/tweakwcs/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'tweakwcs' %}
-{% set version = '0.4.5' %}
+{% set version = '0.4.6' %}
 {% set number = '0' %}
 about:
     home: https://github.com/spacetelescope/{{ name }}


### PR DESCRIPTION
See https://github.com/spacetelescope/tweakwcs/pull/69

As a by-product, C code is gone.