### PR TITLE
Add recipe for jwst-visit-parser

### DIFF
--- a/jwst-visit-parser/bld.bat
+++ b/jwst-visit-parser/bld.bat
@@ -1,0 +1,2 @@
+
+%PYTHON% setup.py install

--- a/jwst-visit-parser/build.sh
+++ b/jwst-visit-parser/build.sh
@@ -1,0 +1,2 @@
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/jwst-visit-parser/meta.yaml
+++ b/jwst-visit-parser/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = 'jwst-visit-parser' %}
+{% set version = '0.1.2' %}
+{% set tag = version %}
+{% set number = '0' %}
+
+about:
+    home: https://github.com/spacetelescope/{{ name }}
+    license: BSD
+    summary: 
+        Python tools for parsing JWST visit (.vst) files
+
+source:
+    git_tag: {{ tag }}
+    git_url: https://github.com/spacetelescope/{{ name }}.git
+
+package:
+    name: {{ name }}
+    version: {{ version }}
+
+build:
+    number: {{ number }}
+    
+requirements:
+    build:
+    - setuptools
+    - numpy {{ numpy }}
+    - python {{ python }}
+    - pytest
+    - astropy
+
+    run:
+    - setuptools
+    - numpy {{ numpy }}
+    - python {{ python }}
+    - pytest
+    - astropy
+
+test:
+    imports:
+      - visitparser


### PR DESCRIPTION
I am trying to follow https://astroconda.readthedocs.io/en/latest/contributing.html. When testing the build locally with `conda build -c http://ssb.stsci.edu/astroconda --skip-existing --python=3.5 jwst-visit-parser` in preparation of this PR, I got an error related to the `atomicwrites` package which I am unable to resolve. 
I am attaching the traceback and the meta.yaml to this PR.

`atomicwrites` is not an explicit dependency of the new package and adding it to the build requirements in meta.yaml does not resolve or alter the problem.