### PR TITLE
wfpc2tools (forgotten update 1.0.4)

### DIFF
--- a/wfpc2tools/meta.yaml
+++ b/wfpc2tools/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'wfpc2tools' %}
-{% set version = '1.0.3' %}
-{% set number = '2' %}
+{% set version = '1.0.4' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}


### PR DESCRIPTION
No code changes from 1.0.3 to 1.0.4. This removes the `.dev` suffix from the released code's version