### PR TITLE
costools: update 1.2.3

### DIFF
--- a/costools/meta.yaml
+++ b/costools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'costools' %}
-{% set version = '1.2.2' %}
+{% set version = '1.2.3' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
* No code changes. Removes .dev suffix from package version