### PR TITLE
nictools: update 1.1.4

### DIFF
--- a/nictools/meta.yaml
+++ b/nictools/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'nictools' %}
-{% set version = '1.1.3' %}
-{% set number = '2' %}
+{% set version = '1.1.4' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}


### PR DESCRIPTION
* No code changes. Removes .dev suffix from package version