### PR TITLE
Reliability improvement in stsci.skypac

### DIFF
--- a/stsci.skypac/meta.yaml
+++ b/stsci.skypac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.skypac' %}
-{% set version = '1.0.3' %}
+{% set version = '1.0.4' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
This release improves `stsci.skypac` in the way it deals with images that almost entirely overlap on the sky by avoiding calling `spherical_geometry` methods in those cases. See https://github.com/spacetelescope/stsci.skypac/pull/49