### PR TITLE
mosviz: add setuptools_scm

### DIFF
--- a/mosviz/meta.yaml
+++ b/mosviz/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - numpy {{ numpy }}
     - python {{ python }}
     - specviz >=0.6.2
+    - setuptools_scm
 
   run:
     - astropy


### PR DESCRIPTION
```python
RuntimeError: Setuptools downloading is disabled in conda build. Be sure to add all
dependencies in the meta.yaml  url=https://pypi.org/simple/setuptools_scm/
```