### PR TITLE
cubeviz: use correct tag

### DIFF
--- a/cubeviz/meta.yaml
+++ b/cubeviz/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = 'cubeviz' %}
-{% set version = '0.3' %}
-{% set tag = 'v' + version %}
+{% set version = '0.3.0' %}
 {% set number = '0' %}
 
 about:
@@ -39,7 +38,7 @@ requirements:
     - pyqt5 <5.12
 
 source:
-    git_tag: {{ tag }}
+    git_tag: {{ version }}
     git_url: https://github.com/spacetelescope/{{ name }}.git
 
 test:


### PR DESCRIPTION
```bash
checkout: 'v0.3'
error: pathspec 'v0.3' did not match any file(s) known to git.
Warning: failed to download source.  If building, will try again after downloading recipe dependencies.
```