### PR TITLE
spectral-cube -> 0.4.4

### DIFF
--- a/spectral-cube/meta.yaml
+++ b/spectral-cube/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'spectral-cube' %}
-{% set version = '0.4.3' %}
+{% set version = '0.4.4' %}
 {% set tag = 'v' + version %}
 {% set number = '0' %}
 


### PR DESCRIPTION
Attempting to fix `cubeviz` build:
```
Solving environment: ...working... failed
failed to get install actions, retrying.  exception was: Unsatisfiable dependencies for platform linux-64: {"spectral-cube[version='>=0.4.4']", "pyqt5[version='<5.12']", 'cubeviz==0.3.0=py36_0'}
WARNING:conda_build.build:failed to get install actions, retrying.  exception was: Unsatisfiable dependencies for platform linux-64: {"spectral-cube[version='>=0.4.4']", "pyqt5[version='<5.12']", 'cubeviz==0.3.0=py36_0'}
```