### PR TITLE
Bump PySynphot to 0.9.13

### DIFF
--- a/pysynphot/meta.yaml
+++ b/pysynphot/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'pysynphot' %}
-{% set version = '0.9.12' %}
+{% set version = '0.9.13' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
0.9.13 is released