### PR TITLE
Remove pin of atomicwrites 1.2.1 in ci-watson recipe

### DIFF
--- a/ci-watson/meta.yaml
+++ b/ci-watson/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     build:
     - pytest
     - setuptools
-      #- atomicwrites=1.2.1
     - atomicwrites
     - python {{ python }}
     run:

--- a/ci-watson/meta.yaml
+++ b/ci-watson/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'ci-watson' %}
 {% set reponame = 'ci_watson' %}
 {% set version = '0.4' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/spacetelescope/{{ reponame }}
@@ -20,7 +20,8 @@ requirements:
     build:
     - pytest
     - setuptools
-    - atomicwrites=1.2.1
+      #- atomicwrites=1.2.1
+    - atomicwrites
     - python {{ python }}
     run:
     - pytest


### PR DESCRIPTION
The broken package that made the initial pin necessary has since been superseded by another build.

```
$ firewatch --time-span 1y | grep atomicwrites
2019-02-08T11:37:07 : main/noarch : atomicwrites-1.3.0-py_0.tar.bz2         
2019-03-22T17:18:14 : main/osx-64 : atomicwrites-1.3.0-py27_1.tar.bz2       
2019-03-22T17:21:19 : main/osx-64 : atomicwrites-1.3.0-py36_1.tar.bz2       
2019-03-22T17:21:44 : main/osx-64 : atomicwrites-1.3.0-py37_1.tar.bz2
```

Addresses #479 by reverting #478