### PR TITLE
Relax openpyxl version pin in pysiaf

### DIFF
--- a/pysiaf/meta.yaml
+++ b/pysiaf/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - matplotlib >=1.4.3
     - lxml >=3.6.4
     - scipy >=0.17
-    - openpyxl ==2.5.0
+    - openpyxl >=2.5.0
     - python {{ python }}
     - setuptools
     - numpydoc
@@ -39,7 +39,7 @@ requirements:
     - matplotlib >=1.4.3
     - lxml >=3.6.4
     - scipy >=0.17
-    - openpyxl ==2.5.0
+    - openpyxl >=2.5.0
     - python {{ python }}
     - requests >=2.21.0
 


### PR DESCRIPTION
This allows building against the dependencies that exist for py37.