### PR TITLE
WebbPSF v0.9.0

### DIFF
--- a/webbpsf-data/meta.yaml
+++ b/webbpsf-data/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'webbpsf-data' %}
-{% set version = '0.8.0' %}
+{% set version = '0.9.0' %}
 {% set number = '0' %}
 
 about:

--- a/webbpsf/meta.yaml
+++ b/webbpsf/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - scipy >=1.0.0
     - matplotlib >=2.0.0
     - poppy >=0.9.0
+    - photutils
     - webbpsf-data ==0.9.0
     - setuptools
     - python {{ python }}
@@ -37,6 +38,7 @@ requirements:
     - scipy >=1.0.0
     - matplotlib >=2.0.0
     - poppy >=0.9.0
+    - photutils
     - webbpsf-data ==0.9.0
     - setuptools
     - python

--- a/webbpsf/meta.yaml
+++ b/webbpsf/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'webbpsf' %}
-{% set version = '0.8.0' %}
+{% set version = '0.9.0' %}
 {% set tag = 'v' + version %}
 {% set number = '1' %}
 
@@ -20,29 +20,29 @@ package:
 
 requirements:
     build:
-    - astropy >=1.2
+    - astropy >=3.0.0
     - numpy {{ numpy }}
-    - scipy >=0.16.0
-    - matplotlib >=1.5.0
-    - poppy >=0.8.0
-    - webbpsf-data ==0.8.0
+    - scipy >=1.0.0
+    - matplotlib >=2.0.0
+    - poppy >=0.9.0
+    - webbpsf-data ==0.9.0
     - setuptools
     - python {{ python }}
     - ipywidgets
     - jwxml
-    - pysiaf >=0.1.8
+    - pysiaf >=0.6.0
     run:
-    - astropy >=1.2
+    - astropy >=3.0.0
     - numpy
-    - scipy >=0.16.0
-    - matplotlib >=1.5.0
-    - poppy >=0.8.0
-    - webbpsf-data ==0.8.0
+    - scipy >=1.0.0
+    - matplotlib >=2.0.0
+    - poppy >=0.9.0
+    - webbpsf-data ==0.9.0
     - setuptools
     - python
     - ipywidgets
     - jwxml
-    - pysiaf >=0.1.8
+    - pysiaf >=0.6.0
 
 source:
     git_tag: {{ tag }}


### PR DESCRIPTION
*2019 November 22*

Note, when upgrading to this version you will need to update to the latest data files as well. This is handled automatically if you use `conda`, otherwise you will need to download and install the data from: `webbpsf-data-0.9.0.tar.gz <https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz>`_.


**JWST Improvements**

- *Added a new capability to model the impact of thermal variations*, from telescope slews relative to the sun, onto mirror alignments and therefore onto PSFs. This new ``thermal_slew`` method  can be used to create a delta OPD for some elapsed time after the slew at either the maximum slew angle, some specified angle, or with a scaling factor applied to maximum case. Once combined with an input OPD (requirements or predicted), the new shape of the mirrors can be used to simulate predicted PSFs some time after a slew. See this `Jupyter notebook <https://github.com/spacetelescope/webbpsf/blob/master/notebooks/Example Construction of OPDs from Delta Time After Slew.ipynb>`_ for examples. [:pr:`269`, :user:`kjbrooks`]
- *Improved wavefront error extrapolation method for field points near FOV corners* that are outside the bounds of Zernike reference table data, in order to provide more seamless extrapolation.  [:pr:`283`, :user:`JarronL`]
- *Improvements in NIRCam optical model*: Updated polynomial model for NIRCam defocus versus wavelength. Adds Zernike coefficients for the wavefront error at NIRCam coronagraphy field points. [:pr:`283`, :user:`JarronL`]
- NIRISS NRM mask was flipped along the X axis to match the as-built instrument and measured PSFs [:pr:`275`, :user:`KevinVolkSTScI`, :user:`anand0xff`, :user:`mperrin`]
- Updated FGS throughput values to use data from the instrument sub-level testing that was done by Comdev/Honeywell, detector quantum efficiency as measured by Teledyne, and the OTE throughput from Lightsey 2012. The throughput file was also updated to include the WAVEUNIT keyword, which removes a warning. [:user:`shanosborne`]]

**WFIRST Improvements**

- *The WFI optical model has been updated to use optical data from the Cycle 8 design revision.* These include updated Zernike coefficients for field-dependent wavefront error, and masked and unmasked pupil images for each SCA, and updated filter throughputs (consistent with values used in Pandeia 1.4.2). The correct pupil file will automatically be selected for each calculation based on the chosen detector position and filter.   The pupil files are consistent with those provided in the WFI cycle 8 reference information, but have been resampled onto a common pixel scale.  See :ref:`WFIRST instrument model details <wfirst_wfi>` for more.  [:pr:`309` :user:`robelgeda`] 
- Note, WFI's filters have been renamed so they all begin with “F”; see the table `here <https://github.com/spacetelescope/webbpsf/pull/309>`_ .
- *The WFI wavelength range has now been extended to cover the 0.48 - 2.0 µm range.* [:pr:`309` :user:`robelgeda`]
- *Expanded ``psf_grid`` method’s functionality so it can also be used to make grids of WFIRST PSFs.* Note that focal plane distortion is not yet implemented for WFIRST PSFs and so ``add_distortion`` keyword should not be used for this case. [:pr:`294`, :user:`shanosborne`]
- *The WFIRST F062 filter bandpass red edge was corrected* from 8000A to 7600A, and associated unit tests were updated to include F062  [:pr:`288`, :user:`robelgeda`]
- The WFI simulations now include the pointing jitter model, using the predicted WFI pointing stability of 14 milliarcseconds per axis. [:pr:`322`, :user:`mperrin`]

**General bug fixes and small changes:**

- *Many improvements in the PSF Grid functionality for generating photutils.GriddedPSFModels*: 

  - New options in ``psf_grid`` to specify both/either the output filename and output directory location. See this `Jupyter notebook <https://github.com/spacetelescope/webbpsf/blob/master/notebooks/Gridded_PSF_Library.ipynb>`_ for examples. [:pr:`294`, :user:`shanosborne`]
  - sFfilenames when saving out a ``psf_grid`` FITS object which has it’s ``filename`` parameter set will now end with ``_det.fits`` instead of the previous ``_det_filt.fits`` [:pr:`294`, :user:`shanosborne`]
  - Update added to ``utils.to_griddedpsfmodel`` where a 2-dimensional array input with a header containing only 1 ``DET_YX`` keyword can be turned into ``GriddedPSFModel`` object without error as it  implies the case of a PSF grid with num_psfs = 1. [:pr:`294`, :user:`shanosborne`]
  - Remove deletion of ``det_yx`` and ``oversamp`` keywords from ``psf_grid`` output to allow for easier implementation in certain cases. Normal case users will have extra keywords but will not change functionality [:pr:`291`, :user:`shanosborne`]
  - Updated normalization of PSFs from ``psf_grid`` to be in surface brightness units, independent of oversampling in order to match the expectation of ``photutils.GriddedPSFModel``. This is diferent than webbpsf's default in which PSFs usually sum to 1 so the counts/pixel varies based on sampling. [:pr:`311`, :user:`mperrin`]
  - Fix bug in how ``pupilopd`` keyword is saved and include extra keywords ``opd_file``, ``opdslice``, ``coronmsk``, and ``pupil`` in the ``psf_grid`` output, both the GriddedPSFModel meta data and FITS object's header [:pr:`284`, :pr:`293`, :pr:`299`, :user:`shanosborne`]

- The ``set_position_from_aperture_name`` method now correctly sets the detector position parameter in the science frame [:pr:`281`, :user:`shanosborne`, :user:`JarronL`, :user:`mperrin`]
- Fix OPD HDUList output from the ``as_fits`` method inside the OPD class to include the previously existing header information [:pr:`270` :user:`laurenmarietta`]
- Added support for secondary mirror moves to the move_sur() method through the move_sm_local method [:pr:`295`, :user:`AldenJurling`]
- Remove ``units`` keyword from ``get_opd`` method, now the wave input needs to be a Wavefront object [:pr:`304`, :user:`shanosborne`]

**Software and Package Infrastructure Updates:**

- Added ``environment.yml`` file [:pr:`321`, :user:`shanosborne`, :user:`mperrin`]
- Remove leftover deprecated syntax ``_getOpticalSystem`` for ``_get_optical_system`` and ``display_PSF`` for ``display_psf`` [:pr:`280`, :pr:`294`, :user:`mperrin`, :user:`shanosborne`]
- Various smaller code cleanup and doc improvements, including code cleanup for better Python PEP8 style guide compliance [:user:`mperrin`, :user:`shanosborne`, :user:`robelgeda`]
- Documentation added and/or updated for a variety of features [:pr:`277`, :pr:`280`, :pr:`318`, :user:`mperrin, @shanosborne`]

CC: @mperrin 