### PR TITLE
Urgent: Update the webbpsf-data Download Link 

### DIFF
--- a/webbpsf-data/meta.yaml
+++ b/webbpsf-data/meta.yaml
@@ -16,4 +16,4 @@ package:
 
 source:
     fn: {{ name }}-{{ version }}.tar.gz
-    url: http://www.stsci.edu/~mperrin/software/webbpsf/{{ name }}-{{ version }}.tar.gz
+    url: https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz


### PR DESCRIPTION
The server with the original `webbpsf-data` data link is being phased out in favor of _stsci.box_. The current link is downloading the wrong files due to an issue on the server side. 

CC @mperrin  