### PR TITLE
Add setuptools_scm to synphot build requirements

### DIFF
--- a/synphot/meta.yaml
+++ b/synphot/meta.yaml
@@ -1,7 +1,7 @@
 {% set reponame = 'synphot_refactor' %}
 {% set name = 'synphot' %}
 {% set version = '0.2.1' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/spacetelescope/{{ reponame }}
@@ -18,6 +18,7 @@ package:
 
 requirements:
     build:
+    - setuptools_scm
     - astropy >=2.0
     - extension-helpers
     - scipy >=0.14


### PR DESCRIPTION
in order to avoid creation of erroneous synphot-0.0.0.dist-info file.