### PR TITLE
Update recipe to use operational toolchains

### DIFF
--- a/hstcal/build.sh
+++ b/hstcal/build.sh
@@ -1,5 +1,12 @@
+# Use the compilers provided by conda. The activation of the build
+# environment defines the GCC and GFORTRAN env vars.
+export CC=$CC
+
+export FCFLAGS="$FCFLAGS -fPIC"
+
 if [[ `uname` == Darwin ]]; then
-    export CC=`which gcc`
+    export CC=$(which $CLANG)
+    export GFORTRAN=$(which gfortran)
     if [[ `uname -m` == x86_64 ]]; then
         export CFLAGS="$CFLAGS -m64"
         export LDFLAGS="$LDFLAGS -m64"

--- a/hstcal/meta.yaml
+++ b/hstcal/meta.yaml
@@ -18,7 +18,10 @@ requirements:
     build:
       - cfitsio >=3.440
       - pkg-config
-      - gcc >=4.7
+      - gcc_linux-64 [linux]
+      - gfortran_linux-64 [linux]
+      # OS-provided compilers and macos SDK used.
+      # The conda toolchains do not work on macos.
 
     run:
       - cfitsio


### PR DESCRIPTION
`gcc` package is no longer available from conda's channels.

Conda-supplied compilers used for linux.
OS-provided compilers are used for Macos.