### PR TITLE
Jwst coronagraph visibility 0.4.2

### DIFF
--- a/astroquery/meta.yaml
+++ b/astroquery/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'astroquery' %}
-{% set version = '0.3.9' %}
+{% set version = '0.3.10' %}
 {% set tag = 'v' + version %}
 {% set number = '0' %}
 
@@ -27,6 +27,7 @@ requirements:
     - beautifulsoup4
     - html5lib
     - secretstorage [linux]
+    - six
     - setuptools
     - python {{ python }}
 
@@ -37,6 +38,7 @@ requirements:
     - beautifulsoup4
     - html5lib
     - secretstorage [linux]
+    - six
     - python
 
 test:

--- a/jwst_coronagraph_visibility/meta.yaml
+++ b/jwst_coronagraph_visibility/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'jwst_coronagraph_visibility' %}
-{% set version = '0.3.0' %}
+{% set version = '0.4.1' %}
 {% set number = '1' %}
 
 about:
@@ -31,14 +31,14 @@ requirements:
     - matplotlib
     - tk
     - requests
-    - jwxml >=0.3.0
+    - pysiaf>=0.6.3
     run:
     - python
     - numpy
     - matplotlib
     - requests
     - tk
-    - jwxml >=0.3.0
+    - pysiaf>=0.6.3
 
 test:
    imports:

--- a/jwst_coronagraph_visibility/meta.yaml
+++ b/jwst_coronagraph_visibility/meta.yaml
@@ -1,10 +1,11 @@
 {% set name = 'jwst_coronagraph_visibility' %}
-{% set version = '0.4.1' %}
+{% set version = '0.4.2' %}
 {% set number = '1' %}
+{% set org = 'spacetelescope' %}
 
 about:
     # Package homepage
-    home: https://github.com/spacetelescope/jwst_coronagraph_visibility
+    home: https://github.com/{{ org }}/{{ name }}
     # Package license
     license: BSD-3-Clause
     # A brief description
@@ -20,25 +21,27 @@ build:
     number: {{ number }}
 
 source:
-    git_tag: {{ version }}
-    git_url: https://github.com/spacetelescope/{{ name }}.git
+    fn: {{ version }}.tar.gz
+    url: https://github.com/{{ org }}/{{ name }}/archive/{{ version }}.tar.gz
 
 requirements:
     build:
     - setuptools
+    - numpydoc
     - python {{ python }}
     - numpy {{ numpy }}
-    - matplotlib
+    - matplotlib>=2.2.4
     - tk
     - requests
-    - pysiaf>=0.6.3
+    - pysiaf >=0.6.3
     run:
+    - numpydoc
     - python
     - numpy
     - matplotlib
     - requests
     - tk
-    - pysiaf>=0.6.3
+    - pysiaf >=0.6.3
 
 test:
    imports:


### PR DESCRIPTION
Releasing new version of JWST Coronagraph Visibility Tool. Fixes bug in current conda install which prevents the program from running.