### PR TITLE
Update pysiaf to v0.7.1

### DIFF
--- a/pysiaf/meta.yaml
+++ b/pysiaf/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'pysiaf' %}
-{% set version = '0.6.3' %}
+{% set version = '0.7.1' %}
 {% set tag = 'v' + version %}
 {% set number = '0' %}
 
@@ -23,8 +23,8 @@ build:
 requirements:
     build:
     - astropy >=1.2
-    - numpy >=1.9
-    - matplotlib >=1.4.3
+    - numpy >=1.13
+    - matplotlib >=3.0.0
     - lxml >=3.6.4
     - scipy >=0.17
     - openpyxl >=2.6.0


### PR DESCRIPTION
Updated `meta.yaml` file for `pysiaf` to include the new version number and the updated dependencies. 

Previous ran `conda build -c http://ssb.stsci.edu/astroconda --skip-existing --python=3.6 pysiaf` for both python 3.6 and 3.7 and they both passed without error.