### PR TITLE
Releasing JWST Coronagraph Visibility Tool version 0.4.4

### DIFF
--- a/jwst_coronagraph_visibility/meta.yaml
+++ b/jwst_coronagraph_visibility/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'jwst_coronagraph_visibility' %}
-{% set version = '0.4.2' %}
+{% set version = '0.4.4' %}
 {% set number = '1' %}
 {% set org = 'spacetelescope' %}
 
@@ -30,18 +30,18 @@ requirements:
     - numpydoc
     - python {{ python }}
     - numpy {{ numpy }}
-    - matplotlib>=2.2.4
+    - matplotlib>=3.1.3
     - tk
     - requests
-    - pysiaf >=0.6.3
+    - pysiaf>=0.7.1
     run:
     - numpydoc
     - python
     - numpy
-    - matplotlib
+    - matplotlib>=3.1.3
     - requests
     - tk
-    - pysiaf >=0.6.3
+    - pysiaf>=0.7.1
 
 test:
    imports:

--- a/jwst_coronagraph_visibility/meta.yaml
+++ b/jwst_coronagraph_visibility/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'jwst_coronagraph_visibility' %}
 {% set version = '0.4.4' %}
-{% set number = '1' %}
+{% set number = '0' %}
 {% set org = 'spacetelescope' %}
 
 about:


### PR DESCRIPTION
- Updated to CVT to use pysiaf 0.7.1 which uses PRD PRDOPSSOC-027.
- Fixed mac bundle issue (app would not open) from previous release.
- Updated unit tests to reflect changes from SIAF in PRDOPSSOC-027.