### PR TITLE
Release asdf 2.5.2 and remove dependency on six

### DIFF
--- a/asdf/meta.yaml
+++ b/asdf/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'asdf' %}
-{% set version = '2.5.1' %}
+{% set version = '2.5.2' %}
 {% set number = '0' %}
 
 about:
@@ -20,7 +20,6 @@ requirements:
     - semantic_version >=2.8
     - pyyaml >=3.10
     - jsonschema >=2.3,<4.0
-    - six >=1.9.0
     - setuptools
     - setuptools_scm
     - numpy {{ numpy }}
@@ -30,7 +29,6 @@ requirements:
     - pyyaml >=3.10
     - jsonschema >=2.3,<4.0
     - pytest
-    - six >=1.9.0
     - setuptools
     - setuptools_scm
     - numpy


### PR DESCRIPTION
We released asdf 2.5.2, which no longer requires `six` as a dependency.