### PR TITLE
Add python as an hstcal build dependency

### DIFF
--- a/hstcal/meta.yaml
+++ b/hstcal/meta.yaml
@@ -16,6 +16,7 @@ package:
 
 requirements:
     build:
+      - python {{ python }}
       - cfitsio >=3.440
       - pkg-config
       - gcc_linux-64 [linux]


### PR DESCRIPTION
It's required by the build tool 'waf'. This will help make requirements more explicit and enforce consistency of which python is used in the build environment.