### PR TITLE
cfitsio update and multi-package rebuild

### DIFF
--- a/cfitsio/meta.yaml
+++ b/cfitsio/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'cfitsio' %}
-{% set version = '3.440' %}
-{% set version_short = '3440' %}
-{% set number = '1' %}
+{% set version = '3.470' %}
+{% set version_short = '3470' %}
+{% set number = '0' %}
 
 about:
     home: http://heasarc.gsfc.nasa.gov/fitsio/fitsio.html

--- a/fitsverify/meta.yaml
+++ b/fitsverify/meta.yaml
@@ -1,12 +1,14 @@
 {% set name = 'fitsverify' %}
 {% set version = '4.18' %}
-{% set number = '7' %}
+{% set number = '8' %}
 # number = 1 ; legacy, links against whatever is provided by available cfitsio package
 # number = 2 ; links against cfitsio < 3.410
 # number = 3 ; links against cfitsio >= 3.410
 # number = 5 ; links against cfitsio >= 3.440
 # number = 6 ; links against cfitsio >= 3.440 (no curl)
 # number = 7 ; links against cfitsio > 3.440 (now provided by conda)
+# number = 8 ; Rebuild to link against cfitsio from Astroconda (conda's cfitsio uses
+#              broken curl things. Astroconda cfitsio is patched to avoid.
 
 about:
     home: http://heasarc.gsfc.nasa.gov/fitsio/fitsio.html

--- a/hstcal/meta.yaml
+++ b/hstcal/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'hstcal' %}
 {% set version = '2.3.1' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}


### PR DESCRIPTION
Build cfitsio 3.470 patched to avoid curl
Rebuild fitsverify to use above
Rebuild hstcal to use above