### PR TITLE
Explicitly define gfortran location in hstcal build

### DIFF
--- a/hstcal/build.sh
+++ b/hstcal/build.sh
@@ -2,7 +2,7 @@
 export FCFLAGS="$FCFLAGS -fPIC"
 
 if [[ `uname` == Darwin ]]; then
-    #export GFORTRAN=$(which gfortran)
+    export GFORTRAN=/sw/bin/gfortran
     if [[ `uname -m` == x86_64 ]]; then
         export CFLAGS="$CFLAGS -m64"
         export LDFLAGS="$LDFLAGS -m64"


### PR DESCRIPTION
It's not on the PATH within the Jenkins job.