### PR TITLE
Add bzip2 dep to cfitsio. Request rebuild of fitsverify to sync.

### DIFF
--- a/cfitsio/meta.yaml
+++ b/cfitsio/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = 'cfitsio' %}
 {% set version = '3.470' %}
 {% set version_short = '3470' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: http://heasarc.gsfc.nasa.gov/fitsio/fitsio.html
@@ -19,10 +19,12 @@ package:
 
 requirements:
     build:
-      - gcc >=4.6
+      - gcc_linux-64 [linux]
+      - bzip2
 
     run:
-      - libgcc >=4.6
+      - libgcc >=4.7
+      - bzip2
 
 source:
     fn: {{ name }}{{ version_short }}.tar.gz

--- a/fitsverify/meta.yaml
+++ b/fitsverify/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'fitsverify' %}
 {% set version = '4.18' %}
-{% set number = '12' %}
+{% set number = '13' %}
 # number = 1 ; legacy, links against whatever is provided by available cfitsio package
 # number = 2 ; links against cfitsio < 3.410
 # number = 3 ; links against cfitsio >= 3.410
@@ -9,6 +9,7 @@
 # number = 7 ; links against cfitsio > 3.440 (now provided by conda)
 # number = 8 ; Rebuild to link against cfitsio from Astroconda (conda's cfitsio uses
 #              broken curl things. Astroconda cfitsio is patched to avoid.
+#        = 13 ; link against new cfitsio build with added bzip2 dependency
 
 about:
     home: http://heasarc.gsfc.nasa.gov/fitsio/fitsio.html


### PR DESCRIPTION
* Also adjust toolchain specification for cfitsio to match approach taken by hstcal. Use OS-supplied compiler on Macos, use conda-supplied compiler on Linux.

