### PR TITLE
Release stsci.skypac v1.0.5

### DIFF
--- a/stsci.skypac/meta.yaml
+++ b/stsci.skypac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.skypac' %}
-{% set version = '1.0.4' %}
+{% set version = '1.0.5' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Bug Fix Release: polygon filling algorithm. See https://github.com/spacetelescope/stsci.skypac/pull/52 and https://github.com/spacetelescope/stsci.skypac/pull/55.

 Also:

- Remove `relic`: https://github.com/spacetelescope/stsci.skypac/pull/53
- Pep8 and docstrings: https://github.com/spacetelescope/stsci.skypac/pull/54 and https://github.com/spacetelescope/stsci.skypac/pull/56

CC: @jhunkeler @rendinam 

Also, PyPi