### PR TITLE
Bump acstools to 3.2.0

### DIFF
--- a/acstools/meta.yaml
+++ b/acstools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'acstools' %}
-{% set version = '3.1.0' %}
+{% set version = '3.2.0' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
https://github.com/spacetelescope/acstools/releases/tag/3.2.0

cc @jryon @nmiles2718