### PR TITLE
Update pysiaf to v0.8.0

### DIFF
--- a/pysiaf/meta.yaml
+++ b/pysiaf/meta.yaml
@@ -22,7 +22,6 @@ build:
 
 requirements:
     build:
-    - setuptools
     - astropy >=1.2
     - numpy >=1.13
     - matplotlib >=3.0.0
@@ -34,10 +33,8 @@ requirements:
     - numpydoc
     - requests >=2.21.0
     - PyQt >=5.0.0
-    - et-xmlfile
 
     run:
-    - setuptools
     - astropy >=1.2
     - numpy >=1.9
     - matplotlib >=1.4.3
@@ -47,7 +44,6 @@ requirements:
     - python {{ python }}
     - requests >=2.21.0
     - PyQt >=5.0.0
-    - et-xmlfile
 
 test:
     imports:

--- a/pysiaf/meta.yaml
+++ b/pysiaf/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'pysiaf' %}
-{% set version = '0.7.1' %}
+{% set version = '0.8.0' %}
 {% set tag = 'v' + version %}
 {% set number = '0' %}
 
@@ -22,6 +22,7 @@ build:
 
 requirements:
     build:
+    - setuptools
     - astropy >=1.2
     - numpy >=1.13
     - matplotlib >=3.0.0
@@ -33,8 +34,10 @@ requirements:
     - numpydoc
     - requests >=2.21.0
     - PyQt >=5.0.0
+    - et-xmlfile
 
     run:
+    - setuptools
     - astropy >=1.2
     - numpy >=1.9
     - matplotlib >=1.4.3
@@ -44,6 +47,7 @@ requirements:
     - python {{ python }}
     - requests >=2.21.0
     - PyQt >=5.0.0
+    - et-xmlfile
 
 test:
     imports:


### PR DESCRIPTION
I updated the `pysiaf` version in `meta.yaml` to `0.8.0` for the new release.

I did have one issues I just wanted to note:

I originally ran `conda build -c http://ssb.stsci.edu/astroconda --skip-existing --python=3.6 pysiaf` and it failed, telling me that "RuntimeError: Setuptools downloading is disabled in conda build. Be sure to add all dependencies in the meta.yaml  url=https://pypi.org/simple/et-xmlfile/". So I added `et-xmlfile` (and `setuptools` for good measure) to the `yaml` file despite the fact the `et_xmlfile` was already listed in the "packages to be installed". This made the check pass and build the package, but only after seemingly installing `et-xmlfile` twice and then clobbering the multiple installations. I'm not sure if that's an issue, but the the `conda build` check is now passing.