### PR TITLE
Update WebbPSF and Poppy for v0.9.1

### DIFF
--- a/poppy/meta.yaml
+++ b/poppy/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'poppy' %}
-{% set version = '0.9.0' %}
+{% set version = '0.9.1' %}
 {% set tag = 'v' + version %}
 {% set number = '0' %}
 
@@ -25,6 +25,7 @@ requirements:
     - scipy >=1.0.0
     - matplotlib >=2.0.0
     - setuptools
+    - setuptools_scm
     - python {{ python }}
     run:
     - astropy >=3.0.0
@@ -32,6 +33,7 @@ requirements:
     - scipy >=1.0.0
     - matplotlib >=2.0.0
     - setuptools
+    - setuptools_scm
     - python
 
 source:

--- a/webbpsf/meta.yaml
+++ b/webbpsf/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'webbpsf' %}
-{% set version = '0.9.0' %}
+{% set version = '0.9.1' %}
 {% set tag = 'v' + version %}
 {% set number = '1' %}
 
@@ -21,32 +21,34 @@ package:
 requirements:
     build:
     - astropy >=3.0.0
-    - numpy {{ numpy }}
+    - numpy >=1.13.0
     - numpydoc
     - scipy >=1.0.0
     - matplotlib >=2.0.0
-    - poppy >=0.9.0
+    - poppy >=0.9.1
     - photutils
     - webbpsf-data ==0.9.0
     - setuptools
+    - setuptools_scm
     - python {{ python }}
     - ipywidgets
     - jwxml
-    - pysiaf >=0.6.0
+    - pysiaf >=0.9.0
     run:
     - astropy >=3.0.0
-    - numpy
+    - numpy >=1.13.0
     - numpydoc
     - scipy >=1.0.0
     - matplotlib >=2.0.0
-    - poppy >=0.9.0
+    - poppy >=0.9.1
     - photutils
     - webbpsf-data ==0.9.0
     - setuptools
+    - setuptools_scm
     - python
     - ipywidgets
     - jwxml
-    - pysiaf >=0.6.0
+    - pysiaf >=0.9.0
 
 source:
     git_tag: {{ tag }}

--- a/webbpsf/meta.yaml
+++ b/webbpsf/meta.yaml
@@ -21,7 +21,7 @@ package:
 requirements:
     build:
     - astropy >=3.0.0
-    - numpy >=1.13.0
+    - numpy {{ numpy }}
     - numpydoc
     - scipy >=1.0.0
     - matplotlib >=2.0.0
@@ -36,7 +36,7 @@ requirements:
     - pysiaf >=0.9.0
     run:
     - astropy >=3.0.0
-    - numpy >=1.13.0
+    - numpy {{ numpy }}
     - numpydoc
     - scipy >=1.0.0
     - matplotlib >=2.0.0


### PR DESCRIPTION
Updating `WebbPSF` and `Poppy` `meta.yaml` files for version 0.9.1 patch release. We are not releasing a new version of `webbpsf-data` with this patch, so that information was left unchanged.

I ran the `conda build` command for both `webbpsf` and `poppy` and both passed without error

cc @mperrin 