### PR TITLE
stsci.imagestats use a tag

### DIFF
--- a/stsci.imagestats/meta.yaml
+++ b/stsci.imagestats/meta.yaml
@@ -28,6 +28,7 @@ requirements:
 
 source:
     git_url: https://github.com/spacetelescope/{{ name }}.git
+    git_tag: {{ version }}
 
 test:
     imports:


### PR DESCRIPTION
Apparently this package has been building `master` in whatever state its in, for however long.