### PR TITLE
Release asdf 2.7.0, update requirements and GitHub URL

### DIFF
--- a/asdf/meta.yaml
+++ b/asdf/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = 'asdf' %}
-{% set version = '2.6.0' %}
+{% set version = '2.7.0' %}
 {% set number = '0' %}
 
 about:
-    home: https://github.com/spacetelescope/{{ name }}
+    home: https://github.com/asdf-format/{{ name }}
     license: BSD
     summary: ASDF (Advanced Scientific Data Format) is a next generation interchange format for scientific data
 
@@ -19,7 +19,7 @@ requirements:
     build:
     - semantic_version >=2.8
     - pyyaml >=3.10
-    - jsonschema >=2.3,<4.0
+    - jsonschema >=3.0.2,<4.0
     - setuptools
     - setuptools_scm
     - numpy {{ numpy }}
@@ -27,7 +27,7 @@ requirements:
     run:
     - semantic_version >=2.8
     - pyyaml >=3.10
-    - jsonschema >=2.3,<4.0
+    - jsonschema >=3.0.2,<4.0
     - pytest
     - setuptools
     - setuptools_scm
@@ -36,7 +36,7 @@ requirements:
 
 source:
   git_tag: {{ version }}
-  git_url: https://github.com/spacetelescope/{{ name }}.git
+  git_url: https://github.com/asdf-format/{{ name }}.git
 
 test:
     commands:


### PR DESCRIPTION
asdf 2.7.0 is released.  This version drops support for jsonschema 2.x, and we've moved the repository to a new GitHub organization.