### PR TITLE
Update pyds9 to the latest master commit

### DIFF
--- a/pyds9/meta.yaml
+++ b/pyds9/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'pyds9' %}
 {% set version = "1.9.0.dev" ~ GIT_DESCRIBE_NUMBER ~ "+" ~ GIT_DESCRIBE_HASH %}
-{% set number = '2' %}
+{% set number = '0' %}
 
 about:
     home: https://github.com/ericmandel/{{ name }}

--- a/pyds9/meta.yaml
+++ b/pyds9/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - python
 
 source:
-    git_rev: c1bf67ab195bd7eb0c662755c2df35df014482b0
+    git_rev: f1f0aae83c9d5da05b457f72501ec127f787c0f4
     git_url: https://github.com/ericmandel/{{ name }}.git
 
 test:


### PR DESCRIPTION
Ref #628. This is to pickup the latest commits with the six fix, otherwise the package crashes with recent astropy versions.