### PR TITLE
bump gwcs to 0.15.0

### DIFF
--- a/gwcs/meta.yaml
+++ b/gwcs/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'gwcs' %}
-{% set version = '0.14.0' %}
+{% set version = '0.15.0' %}
 {% set number = '0' %}
 
 about:
@@ -24,7 +24,7 @@ requirements:
     - python {{ python }}
     run:
     - asdf
-    - astropy >=3.1
+    - astropy >=4.1
     - numpy
     - python
 


### PR DESCRIPTION
nden: "Note that it requires astropy 4.1. Not sure if this is a problem for astroconda."