### PR TITLE
pysiaf: stop building as egg

### DIFF
--- a/pysiaf/bld.bat
+++ b/pysiaf/bld.bat
@@ -1,2 +1,1 @@
-
-%PYTHON% setup.py install
+%PYTHON% setup.py install --single-version-externally-managed --record=root.txt

--- a/pysiaf/build.sh
+++ b/pysiaf/build.sh
@@ -1,2 +1,1 @@
-
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=root.txt

--- a/pysiaf/meta.yaml
+++ b/pysiaf/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - numpydoc
     - requests >=2.21.0
     - PyQt >=5.0.0
+    - et_xmlfile
 
     run:
     - astropy >=1.2


### PR DESCRIPTION
Add missing dependency `et_xmlfile`. 
`pysiaf` does not list this as a requirement itself.