### PR TITLE
gwcs: disable py36

### DIFF
--- a/gwcs/meta.yaml
+++ b/gwcs/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'gwcs' %}
 {% set version = '0.16.1' %}
-{% set number = '0' %}
+{% set number = '1' %}
 
 about:
     home: https://github.com/spacetelescope/{{ name }}
@@ -9,7 +9,7 @@ about:
 
 build:
     number: {{ number }}
-    skip: True [py27]
+    skip: True [py27 and py36]
 
 package:
     name: {{ name }}


### PR DESCRIPTION
The build doesn't work and has been failing for a very long time.