### PR TITLE
MNT: Bump synphotses

### DIFF
--- a/pysynphot/meta.yaml
+++ b/pysynphot/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'pysynphot' %}
-{% set version = '1.0.0' %}
+{% set version = '1.0.1' %}
 {% set number = '0' %}
 
 about:

--- a/stsynphot/meta.yaml
+++ b/stsynphot/meta.yaml
@@ -1,6 +1,6 @@
 {% set reponame = 'stsynphot_refactor' %}
 {% set name = 'stsynphot' %}
-{% set version = '1.0.0' %}
+{% set version = '1.1.0' %}
 {% set number = '0' %}
 
 about:
@@ -19,9 +19,9 @@ package:
 requirements:
     build:
     - synphot >=0.3
-    - astropy >=3
+    - astropy >=3.2
     - extension-helpers
-    - scipy >=0.14
+    - scipy >=1.1
     - beautifulsoup4
     - numpy {{ numpy }}
     - pytest
@@ -31,8 +31,8 @@ requirements:
 
     run:
     - synphot >=0.3
-    - astropy >=3
-    - scipy >=0.14
+    - astropy >=3.2
+    - scipy >=1.1
     - beautifulsoup4
     - numpy
     - pytest

--- a/synphot/meta.yaml
+++ b/synphot/meta.yaml
@@ -1,6 +1,6 @@
 {% set reponame = 'synphot_refactor' %}
 {% set name = 'synphot' %}
-{% set version = '1.0.1' %}
+{% set version = '1.1.0' %}
 {% set number = '0' %}
 
 about:
@@ -19,16 +19,16 @@ package:
 requirements:
     build:
     - setuptools_scm
-    - astropy >=3
+    - astropy >=3.2
     - extension-helpers
-    - scipy >=0.14
+    - scipy >=1.1
     - numpy {{ numpy }}
     - pytest
     - setuptools
     - python {{ python }}
     run:
-    - astropy >=3
-    - scipy >=0.14
+    - astropy >=3.2
+    - scipy >=1.1
     - numpy
     - pytest
     - python


### PR DESCRIPTION
Triple play!

* https://github.com/spacetelescope/pysynphot/releases/tag/1.0.1
* https://github.com/spacetelescope/synphot_refactor/releases/tag/1.1.0
* https://github.com/spacetelescope/stsynphot_refactor/releases/tag/1.1.0

People will want to use these with `astropy` 4.3 that is coming out soon.