### PR TITLE
Release 1.0.6 - package maintenance

### DIFF
--- a/stsci.skypac/meta.yaml
+++ b/stsci.skypac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.skypac' %}
-{% set version = '1.0.5' %}
+{% set version = '1.0.6' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Switch to using `bitmask` module from `stsci.tools` to `astropy.nddata`. See https://github.com/spacetelescope/stsci.skypac/pull/61