### PR TITLE
Package maintenance. Release skypac 1.0.7

### DIFF
--- a/stsci.skypac/meta.yaml
+++ b/stsci.skypac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.skypac' %}
-{% set version = '1.0.6' %}
+{% set version = '1.0.7' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Effectively undoes https://github.com/spacetelescope/stsci.skypac/pull/61

Switch back to using bitmask module from stsci.tools. See  https://github.com/spacetelescope/stsci.skypac/pull/62