### PR TITLE
Release stsci.image 2.3.4

### DIFF
--- a/stsci.image/meta.yaml
+++ b/stsci.image/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.image' %}
-{% set version = '2.3.3' %}
+{% set version = '2.3.4' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Minor code clean up to deal with `numpy` deprecation warnings.