### PR TITLE
Maintenance release of stsci.skypac v1.0.8

### DIFF
--- a/stsci.skypac/meta.yaml
+++ b/stsci.skypac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'stsci.skypac' %}
-{% set version = '1.0.7' %}
+{% set version = '1.0.8' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
Fix deprecation warnings from `numpy` due to use of `numpy` aliases to fundamental Python data types. See https://github.com/spacetelescope/stsci.skypac/pull/63 for more details.