### PR TITLE
Bump PySynphot to 2.0.0

### DIFF
--- a/pysynphot/meta.yaml
+++ b/pysynphot/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'pysynphot' %}
-{% set version = '1.0.1' %}
+{% set version = '2.0.0' %}
 {% set number = '0' %}
 
 about:
@@ -8,6 +8,7 @@ about:
     summary: Synthetic Photometry Package
 build:
     number: {{ number }}
+    skip: true  # [py2k]
 package:
     name: {{ name }}
     version: {{ version }}


### PR DESCRIPTION
Bump PySynphot to 2.0.0 for Python 3 only.