### PR TITLE
Add recipe for jwebbinar notebooks

### DIFF
--- a/jwebbinar_prep/build.sh
+++ b/jwebbinar_prep/build.sh
@@ -1,0 +1,14 @@
+if [[ -z ${PKG_NAME} ]]; then
+    echo "Conda build has changed out from under you. PKG_NAME is undefined..."
+    exit 1
+fi
+
+dest="${PREFIX}/share/jwebbinar_notebooks"
+usedir="$(pwd)"
+
+if [[ -d ${usedir}/work ]]; then
+    usedir=${usedir}/work
+fi
+
+mkdir -p "${dest}"
+rsync -av --exclude '.git*' --exclude 'README.md' --exclude '.DS_Store' "${usedir}" "${dest}"/

--- a/jwebbinar_prep/meta.yaml
+++ b/jwebbinar_prep/meta.yaml
@@ -1,0 +1,19 @@
+{% set name = 'jwebbinar_prep' %}
+{% set version = 'v0.1' %}
+{% set number = '0' %}
+
+about:
+  home: https://github.com/spacetelscope/{{ name }}
+  license: BSD
+  summary: Collection of JWST JWebbinar notebooks
+
+build:
+  number: {{ number }}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  git_tag: {{ version }}
+  git_url: https://github.com/spacetelescope/{{ name }}.git


### PR DESCRIPTION
This conda package is needed to deliver the JWebbinar notebooks in DE Build E.