### PR TITLE
Bump synphot to 1.1.1

### DIFF
--- a/synphot/meta.yaml
+++ b/synphot/meta.yaml
@@ -1,6 +1,6 @@
 {% set reponame = 'synphot_refactor' %}
 {% set name = 'synphot' %}
-{% set version = '1.1.0' %}
+{% set version = '1.1.1' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
synphot 1.1.1 is needed to be compatible with astropy 5.0.

- [x] Fix the release first before getting this out of draft form.