### PR TITLE
WebbPSF and poppy v1.0.X updates

### DIFF
--- a/poppy/meta.yaml
+++ b/poppy/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'poppy' %}
-{% set version = '0.9.2' %}
+{% set version = '1.0.1' %}
 {% set tag = 'v' + version %}
 {% set number = '0' %}
 
@@ -20,18 +20,18 @@ package:
 
 requirements:
     build:
-    - astropy >=3.2.0
-    - numpy {{ numpy }}
-    - scipy >=1.0.0
-    - matplotlib >=2.0.0
+    - astropy >=4.0.0
+    - numpy >=1.18.0
+    - scipy >=1.5.0
+    - matplotlib >=3.2.0
     - setuptools
     - setuptools_scm
     - python {{ python }}
     run:
-    - astropy >=3.2.0
-    - numpy
-    - scipy >=1.0.0
-    - matplotlib >=2.0.0
+    - astropy >=4.0.0
+    - numpy >=1.18.0
+    - scipy >=1.5.0
+    - matplotlib >=3.2.0
     - setuptools
     - setuptools_scm
     - python

--- a/webbpsf-data/meta.yaml
+++ b/webbpsf-data/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'webbpsf-data' %}
-{% set version = '0.9.2' %}
+{% set version = '1.0.0' %}
 {% set number = '1' %}
 
 about:
@@ -16,4 +16,4 @@ package:
 
 source:
     fn: {{ name }}-{{ version }}.tar.gz
-    url: https://stsci.box.com/shared/static/r7k2m3ruxb7a7a7t172epr4kq5ibmo78.gz
+    url: https://stsci.box.com/shared/static/ftj8esrt0apzbnff8j6m5kseii2jzy9e.gz

--- a/webbpsf/meta.yaml
+++ b/webbpsf/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'webbpsf' %}
-{% set version = '0.9.2' %}
+{% set version = '1.0.0' %}
 {% set tag = 'v' + version %}
 {% set number = '1' %}
 
@@ -20,35 +20,35 @@ package:
 
 requirements:
     build:
-    - astropy >=3.0.0
-    - numpy {{ numpy }}
+    - astropy >=4.0.0
+    - numpy >=1.18.0
     - numpydoc
-    - scipy >=1.0.0
-    - matplotlib >=2.0.0
-    - poppy ==0.9.2
+    - scipy >=1.5.0
+    - matplotlib >=3.2.0
+    - poppy ==1.0.1
     - photutils
-    - webbpsf-data ==0.9.2
+    - webbpsf-data ==1.0.0
     - setuptools
     - setuptools_scm
     - python {{ python }}
     - ipywidgets
-    - jwxml
-    - pysiaf >=0.9.0
+    - pysiaf >=0.11.0
+    - synphot >=1.0.0
     run:
-    - astropy >=3.0.0
-    - numpy {{ numpy }}
+    - astropy >=4.0.0
+    - numpy >=1.18.0
     - numpydoc
-    - scipy >=1.0.0
-    - matplotlib >=2.0.0
-    - poppy ==0.9.2
+    - scipy >=1.5.0
+    - matplotlib >=3.2.0
+    - poppy ==1.0.1
     - photutils
-    - webbpsf-data ==0.9.2
+    - webbpsf-data ==1.0.0
     - setuptools
     - setuptools_scm
     - python
     - ipywidgets
-    - jwxml
-    - pysiaf >=0.9.0
+    - pysiaf >=0.11.0
+    - synphot >=1.0.0
 
 source:
     git_tag: {{ tag }}

--- a/webbpsf/meta.yaml
+++ b/webbpsf/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - scipy >=1.5.0
     - matplotlib >=3.2.0
     - poppy ==1.0.1
-    - photutils
+    - photutils >=1.0.0
     - webbpsf-data ==1.0.0
     - setuptools
     - setuptools_scm
@@ -41,7 +41,7 @@ requirements:
     - scipy >=1.5.0
     - matplotlib >=3.2.0
     - poppy ==1.0.1
-    - photutils
+    - photutils >=1.0.0
     - webbpsf-data ==1.0.0
     - setuptools
     - setuptools_scm


### PR DESCRIPTION
Changes cover `poppy`, `webbpsf`, and `webbpsf-data`.

I switched away from using the `{{ numpy }}` variable because our minimum required version (1.18.0) is now higher than the one specified in `conda_build_config.yaml` (1.14). If there's a better solution, please let me know.