### PR TITLE
Bump reftools to 2.1.0

### DIFF
--- a/reftools/meta.yaml
+++ b/reftools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'reftools' %}
-{% set version = '2.0.0' %}
+{% set version = '2.1.0' %}
 {% set number = '0' %}
 
 about:


### PR DESCRIPTION
https://github.com/spacetelescope/reftools/releases/tag/2.1.0