### PR TITLE
New PyRAF 2.2.1 release, supporting Python 3

### DIFF
--- a/pyraf/build.sh
+++ b/pyraf/build.sh
@@ -3,13 +3,4 @@ if [[ `uname -s` == "Darwin" ]]; then
     export LDFLAGS="-L/opt/X11/lib"
 fi
 
-if [[ $PY3K > 0 ]]; then
-set +e
-    echo Running 2to3...
-    2to3 -w . &>/dev/null
-    if [[ $? != 0 ]]; then
-        echo "ERROR: 2to3 technically failed!"
-    fi
-fi
-
 $PYTHON -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv

--- a/pyraf/meta.yaml
+++ b/pyraf/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'pyraf' %}
-{% set version = '2.2.1rc1' %}
+{% set version = '2.2.1' %}
 {% set tag = 'v' + version %}
 {% set number = '0' %}
 

--- a/pyraf/meta.yaml
+++ b/pyraf/meta.yaml
@@ -1,9 +1,10 @@
 {% set name = 'pyraf' %}
-{% set version = '2.1.15' %}
-{% set number = '1' %}
+{% set version = '2.2.1rc1' %}
+{% set tag = 'v' + version %}
+{% set number = '0' %}
 
 about:
-    home: https://github.com/spacetelescope/{{ name }}
+    home: https://github.com/iraf-community/{{ name }}
     license: BSD
     summary: |
         Provides a Pythonic interface to IRAF
@@ -17,32 +18,31 @@ package:
 
 requirements:
     build:
-    - d2to1
-    - stsci.distutils
     - astropy >=1.1
+    - configobj >=5
     - ipython
     - matplotlib
     - pyobjc-core >=3.0.4 [osx]
     - pyobjc-framework-cocoa >=3.0.4 [osx]
     - pyobjc-framework-quartz >=3.0.4 [osx]
-    - stsci.tools
     - setuptools
+    - setuptools_scm
     - numpy {{ numpy }}
     - python {{ python }}
     run:
     - astropy >=1.1
+    - configobj >=5
     - ipython
     - matplotlib
     - pyobjc-core >=3.0.4 [osx]
     - pyobjc-framework-cocoa >=3.0.4 [osx]
     - pyobjc-framework-quartz >=3.0.4 [osx]
-    - stsci.tools
     - numpy
     - python
 
 source:
-    git_tag: {{ version }}
-    git_url: https://github.com/spacetelescope/{{ name }}.git
+    git_tag: {{ tag }}
+    git_url: https://github.com/iraf-community/{{ name }}.git
 
 test:
     commands:


### PR DESCRIPTION
Hello. You probably don't know me, since @jhunkeler & Matt Rendina have moved onto other things, but I'm James, the (occasional) Astroconda contributor and IRAF repo maintainer at Gemini (and before that collaborator on Ureka).

Since STScI officially transferred PyRAF to the "IRAF community" (https://github.com/iraf-community/pyraf/issues/60, https://github.com/iraf-community/pyraf/issues/70), Ole Streicher and I have been working to improve its compatibility with Python 3, resulting in a new release 2.2.1 a few days ago, which finally passes all of our testing with Gemini IRAF on Python 3. All releases prior to this one worked more reliably and (before 2.2.0) faster under Python 2, which is the reason (along with STSDAS containing a few Python 2 scripts) that IRAF users were advised to stick to Python 2 at https://astroconda.readthedocs.io/en/latest/installation.html#iraf-install.

This PR updates the Astroconda recipe with the new URL, version & dependencies and gets rid of the no-longer-needed 2to3 conversion. I'm not sure whether you still _want_ to provide new `pyraf` builds in the main Astroconda channel, since STScI has stopped supporting IRAF (?), but Gemini has been depending on those and I don't want to assume that we should move the package(s) downstream without checking with you first. I think some of STScI's users would also find it useful :wink:. Note that this version is only for Python 3, while the Python 2 build can remain at 2.1.15.

The existing recipe's dependency list includes `astropy`, which `pyraf` only uses for running its self-tests, and `ipython` & `matplotlib`, which are optional at run-time. I don't know whether you have any opinion on keeping those as hard dependencies, but the last 2 are probably useful to pull in, since users might not know to install them separately and are likely to have them anyway. Another couple of dependencies have been removed (after a bit of discussion [here](https://github.com/iraf-community/pyraf/issues/127#issuecomment-1060782829) and [here](https://github.com/iraf-community/pyraf/pull/129#pullrequestreview-905920209)) and a couple of general ones added.

Let me know whether you're going to make some builds for this (we specifically need `py37` and ideally later versions too) and if not, I'll host them in a Gemini conda channel instead. Thanks!